### PR TITLE
Use commented lines of YAML as conversion metadata format

### DIFF
--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -680,7 +680,8 @@ class ConversionSpec(ConversionBase):
         reader: CSV reader object as returned by csv.reader
             The reader object must already be advanced to the rules section, so that
             the first read yields the data header.
-        offset: Number of lines of the metadata block.
+        offset: int
+            Number of lines of the metadata block.
 
         Returns
         -------
@@ -696,9 +697,7 @@ class ConversionSpec(ConversionBase):
             raise ValueError("Last column must be 'comment', but isn't.")
         aux_names = header[1:-2]
         for row in reader:
-            line_num = reader.line_num
-            if offset is not None:
-                line_num += offset  # YAML metadata block
+            line_num = reader.line_num + offset
             irow = iter(row)
             try:
                 rule_specs.append(
@@ -707,7 +706,7 @@ class ConversionSpec(ConversionBase):
                     )
                 )
             except ValueError as err:
-                raise ValueError(f"Error in line {reader.line_num + offset}: {err}")
+                raise ValueError(f"Error in line {line_num}: {err}")
 
         return a_name, b_name, aux_names, rule_specs
 

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -3,7 +3,6 @@ import csv
 import dataclasses
 import datetime
 import pathlib
-import re
 import typing
 from typing import TYPE_CHECKING
 

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -662,9 +662,6 @@ class ConversionSpec(ConversionBase):
             line = fd.readline()
         fd.seek(last_pos)
         meta_data = sy.load(yaml_header, schema=cls._strictyaml_metadata_schema).data
-        for idx, key in enumerate(meta_data.keys()):
-            if key not in cls._meta_data_keys:
-                raise ValueError(f"Unknown meta data key in line {idx + 1}: {key}.")
 
         return meta_data
 

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -213,6 +213,7 @@ class ConversionRuleSpec:
         irow: typing.Iterator[str],
         aux_names: typing.List[str],
         line_number: typing.Optional[int] = None,
+        offset: typing.Optional[int] = None,
     ) -> "ConversionRuleSpec":
         """Parse a ConversionRuleSpec from a row in a CSV file.
 
@@ -695,11 +696,14 @@ class ConversionSpec(ConversionBase):
             raise ValueError("Last column must be 'comment', but isn't.")
         aux_names = header[1:-2]
         for row in reader:
+            line_num = reader.line_num
+            if offset is not None:
+                line_num += offset  # YAML metadata block
             irow = iter(row)
             try:
                 rule_specs.append(
                     ConversionRuleSpec.from_csv_row(
-                        irow, aux_names=aux_names, line_number=reader.line_num
+                        irow, aux_names=aux_names, line_number=line_num
                     )
                 )
             except ValueError as err:

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -626,7 +626,7 @@ class ConversionSpec(ConversionBase):
     @classmethod
     def _read_csv_meta(cls, fd: typing.TextIO):
         """Read the metadata section of a CSV conversion specification file. It consists
-        of YAML key, value pairs, one pair on each line separated by a clon.
+        of YAML key, value pairs, one pair on each line separated by a colon.
         Each line is prefixed with the comment char "#".
 
         Parameters

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -661,7 +661,6 @@ class ConversionSpec(ConversionBase):
             last_pos = fd.tell()
             line = fd.readline()
         fd.seek(last_pos)
-        print(yaml_header)
         meta_data = sy.load(yaml_header, schema=cls._strictyaml_metadata_schema).data
         for idx, key in enumerate(meta_data.keys()):
             if key not in cls._meta_data_keys:

--- a/climate_categories/_conversions.py
+++ b/climate_categories/_conversions.py
@@ -647,7 +647,8 @@ class ConversionSpec(ConversionBase):
         last_pos = fd.tell()
         line = fd.readline()
         while line.startswith("#"):
-            yaml_header += re.sub(r"^#\s?", "", line)
+            # remove leading comment and whitespace
+            yaml_header += line[1:].lstrip()
             last_pos = fd.tell()
             line = fd.readline()
         fd.seek(last_pos)

--- a/climate_categories/data/conversion.IPCC1996.IPCC2006.csv
+++ b/climate_categories/data/conversion.IPCC1996.IPCC2006.csv
@@ -1,7 +1,6 @@
-references,IPCC 2006\, 2006 IPCC Guidelines for National Greenhouse Gas Inventories\, Prepared by the National Greenhouse Gas Inventories Programme\, Eggleston H.S.\, Buendia L.\, Miwa K.\, Ngara T. and Tanabe K. (eds). Volume 1\, Chapter 8\, Table 8.2\ https://www.ipcc-nggip.iges.or.jp/public/2006gl/vol1.html
-institution,IPCC
-last_update,2021-07-09
-
+# references: "IPCC 2006, 2006 IPCC Guidelines for National Greenhouse Gas Inventories, Prepared by the National Greenhouse Gas Inventories Programme, Eggleston H.S., Buendia L., Miwa K., Ngara T. and Tanabe K. (eds). Volume 1, Chapter 8d, Table 8.2  https://www.ipcc-nggip.iges.or.jp/public/2006gl/vol1.html"
+# institution: IPCC
+# last_update: 2021-07-09
 IPCC1996,gas,IPCC2006,comment
 0,,0,
 1,,1,

--- a/climate_categories/tests/data/broken_conversion_not_allowed.csv
+++ b/climate_categories/tests/data/broken_conversion_not_allowed.csv
@@ -1,0 +1,14 @@
+# comment: A broken conversion specification file
+# version: 1.2.3.4
+# references: expert judgement
+# last_update: 2099-12-31
+A,aux1,aux2,B,comment
+asdf + fdsa,,,asdf
+A.5,3 4 A "argl-5", "B A" B A,4
+b + "argl.5" + c,,,D,nobody needs argl
+b + "argl\,5" + c,,,D
+b + "argl\\"5" + not_allowed,,,D
+b + "argl\\"5" + c,,,D+E
+"argl\,5",,,D
+"+" - "-",,,"-"
+b,,,asdf+4

--- a/climate_categories/tests/data/broken_conversion_not_existing.csv
+++ b/climate_categories/tests/data/broken_conversion_not_existing.csv
@@ -1,0 +1,14 @@
+# comment: A broken conversion specification file
+# version: 1.2.3.4
+# references: expert judgement
+# last_update: 2099-12-31
+A,aux1,aux2,B,comment
+asdf + fdsa,,,asdf
+A.5,3 4 A "argl-5", "B A" B A,4
+b + "argl.5" + c,,,D,nobody needs argl
+b + "argl\,5" + c,,,D
+b + "argl\\"5" + notexisting,,,D
+b + "argl\\"5" + c,,,D+E
+"argl\,5",,,D
+"+" - "-",,,"-"
+b,,,asdf+4

--- a/climate_categories/tests/data/good_conversion.csv
+++ b/climate_categories/tests/data/good_conversion.csv
@@ -1,8 +1,7 @@
-comment,A correct conversion specification file
-version,1.2.3.4
-references,expert judgement
-last_update,2099-12-31
-
+# comment: A correct conversion specification file
+# version: 1.2.3.4
+# references: expert judgement
+# last_update: 2099-12-31
 A,aux1,aux2,B,comment
 asdf + fdsa,,,asdf
 A.5,3 4 A "argl-5", "B A" B A,4

--- a/climate_categories/tests/data/good_conversion_reversed.csv
+++ b/climate_categories/tests/data/good_conversion_reversed.csv
@@ -1,8 +1,7 @@
-comment,A correct conversion specification file
-version,1.2.3.4
-references,expert judgement
-last_update,2099-12-31
-
+# comment: A correct conversion specification file
+# version: 1.2.3.4
+# references: expert judgement
+# last_update: 2099-12-31
 B,aux1,aux2,A,comment
 asdf,,,asdf + fdsa
 4,3 4 A "argl-5", "B A" B A,A.5

--- a/climate_categories/tests/test_conversions.py
+++ b/climate_categories/tests/test_conversions.py
@@ -149,7 +149,7 @@ class TestConversionSpec:
             factors_categories_a={"asdf": 1, "fdsa": 1},
             factors_categories_b={"asdf": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=2,
+            csv_line_number=6,
             csv_original_text="asdf + fdsa,,,asdf",
         )
         assert conv.rule_specs[1] == conversions.ConversionRuleSpec(
@@ -159,7 +159,7 @@ class TestConversionSpec:
                 "aux1": {"3", "4", "A", "argl-5"},
                 "aux2": {"B A", "A", "B"},
             },
-            csv_line_number=3,
+            csv_line_number=7,
             csv_original_text='A.5,3 4 A "argl-5", "B A" B A,4',
         )
         assert conv.rule_specs[2] == conversions.ConversionRuleSpec(
@@ -167,49 +167,49 @@ class TestConversionSpec:
             factors_categories_b={"D": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
             comment="nobody needs argl",
-            csv_line_number=4,
+            csv_line_number=8,
             csv_original_text='b + "argl.5" + c,,,D,nobody needs argl',
         )
         assert conv.rule_specs[3] == conversions.ConversionRuleSpec(
             factors_categories_a={"b": 1, "argl,5": 1, "c": 1},
             factors_categories_b={"D": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=5,
+            csv_line_number=9,
             csv_original_text='b + "argl,5" + c,,,D',
         )
         assert conv.rule_specs[4] == conversions.ConversionRuleSpec(
             factors_categories_a={"b": 1, 'argl"5': 1, "c": 1},
             factors_categories_b={"D": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=6,
+            csv_line_number=10,
             csv_original_text='b + "argl\\"5" + c,,,D',
         )
         assert conv.rule_specs[5] == conversions.ConversionRuleSpec(
             factors_categories_a={"b": 1, 'argl"5': 1, "c": 1},
             factors_categories_b={"D": 1, "E": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=7,
+            csv_line_number=11,
             csv_original_text='b + "argl\\"5" + c,,,D+E',
         )
         assert conv.rule_specs[6] == conversions.ConversionRuleSpec(
             factors_categories_a={"argl,5": 1},
             factors_categories_b={"D": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=8,
+            csv_line_number=12,
             csv_original_text='"argl,5",,,D',
         )
         assert conv.rule_specs[7] == conversions.ConversionRuleSpec(
             factors_categories_a={"+": 1, "-": -1},
             factors_categories_b={"-": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=9,
+            csv_line_number=13,
             csv_original_text='"+" - "-",,,"-"',
         )
         assert conv.rule_specs[8] == conversions.ConversionRuleSpec(
             factors_categories_a={"b": 1},
             factors_categories_b={"asdf": 1, "4": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=10,
+            csv_line_number=14,
             csv_original_text="b,,,asdf+4",
         )
 

--- a/climate_categories/tests/test_conversions.py
+++ b/climate_categories/tests/test_conversions.py
@@ -3,6 +3,7 @@
 import datetime
 import importlib
 import importlib.resources
+from io import StringIO
 
 import pytest
 
@@ -147,7 +148,7 @@ class TestConversionSpec:
             factors_categories_a={"asdf": 1, "fdsa": 1},
             factors_categories_b={"asdf": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=7,
+            csv_line_number=2,
             csv_original_text="asdf + fdsa,,,asdf",
         )
         assert conv.rule_specs[1] == conversions.ConversionRuleSpec(
@@ -157,7 +158,7 @@ class TestConversionSpec:
                 "aux1": {"3", "4", "A", "argl-5"},
                 "aux2": {"B A", "A", "B"},
             },
-            csv_line_number=8,
+            csv_line_number=3,
             csv_original_text='A.5,3 4 A "argl-5", "B A" B A,4',
         )
         assert conv.rule_specs[2] == conversions.ConversionRuleSpec(
@@ -165,87 +166,76 @@ class TestConversionSpec:
             factors_categories_b={"D": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
             comment="nobody needs argl",
-            csv_line_number=9,
+            csv_line_number=4,
             csv_original_text='b + "argl.5" + c,,,D,nobody needs argl',
         )
         assert conv.rule_specs[3] == conversions.ConversionRuleSpec(
             factors_categories_a={"b": 1, "argl,5": 1, "c": 1},
             factors_categories_b={"D": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=10,
+            csv_line_number=5,
             csv_original_text='b + "argl,5" + c,,,D',
         )
         assert conv.rule_specs[4] == conversions.ConversionRuleSpec(
             factors_categories_a={"b": 1, 'argl"5': 1, "c": 1},
             factors_categories_b={"D": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=11,
+            csv_line_number=6,
             csv_original_text='b + "argl\\"5" + c,,,D',
         )
         assert conv.rule_specs[5] == conversions.ConversionRuleSpec(
             factors_categories_a={"b": 1, 'argl"5': 1, "c": 1},
             factors_categories_b={"D": 1, "E": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=12,
+            csv_line_number=7,
             csv_original_text='b + "argl\\"5" + c,,,D+E',
         )
         assert conv.rule_specs[6] == conversions.ConversionRuleSpec(
             factors_categories_a={"argl,5": 1},
             factors_categories_b={"D": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=13,
+            csv_line_number=8,
             csv_original_text='"argl,5",,,D',
         )
         assert conv.rule_specs[7] == conversions.ConversionRuleSpec(
             factors_categories_a={"+": 1, "-": -1},
             factors_categories_b={"-": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=14,
+            csv_line_number=9,
             csv_original_text='"+" - "-",,,"-"',
         )
         assert conv.rule_specs[8] == conversions.ConversionRuleSpec(
             factors_categories_a={"b": 1},
             factors_categories_b={"asdf": 1, "4": 1},
             auxiliary_categories={"aux1": set(), "aux2": set()},
-            csv_line_number=15,
+            csv_line_number=10,
             csv_original_text="b,,,asdf+4",
         )
 
         assert repr(conv) == "<ConversionSpec 'A' <-> 'B' with 9 rules>"
 
     def test_formula_broken(self):
-        csv = ["comment,no comment", "", "A,B,comment", "A.1+,C,broken formula"]
-        with pytest.raises(ValueError, match="line 4.*Could not parse"):
+        csv = StringIO(
+            "# comment: no comment\n"
+            "A,species,B,comment\n"
+            "A.1+,something,C,broken formula\n"
+        )
+        with pytest.raises(ValueError, match="line 2.*Could not parse"):
             climate_categories._conversions.ConversionSpec.from_csv(csv)
-
-    def test_meta_data_incomplete(self):
-        csv = ["comment,no comment", "references"]
-        with pytest.raises(
-            ValueError, match="Meta data specification is incomplete in line 2"
-        ):
-            climate_categories._conversions.ConversionSpec.from_csv(csv)
-
-    def test_extraneous_comma(self):
-        csv = ["comment,you know, nothing really works"]
-        with pytest.raises(ValueError, match="did you forget to escape a comma?"):
-            climate_categories._conversions.ConversionSpec.from_csv(csv)
-
-        csv = ["comment,you know\\, nothing really works", "", "A,B,comment"]
-        cr = climate_categories._conversions.ConversionSpec.from_csv(csv)
-        assert cr.comment == "you know, nothing really works"
 
     def test_unknown_meta_data(self):
-        csv = [
-            "comment,no comment",
-            "interjection,What you guys are referring to as Linux",
-        ]
+        csv = StringIO(
+            "# comment: no comment\n"
+            "# interjection: What you guys are referring to as Linux\n"
+        )
         with pytest.raises(
             ValueError, match="Unknown meta data key in line 2: interjection"
         ):
             climate_categories._conversions.ConversionSpec.from_csv(csv)
 
     def test_comment_missing(self):
-        csv = ["comment,no comment", "", "A,aux,B", "A.1,D,A.2"]
+        # csv = ["comment: no comment", "A,aux,B", "A.1,D,A.2"]
+        csv = StringIO("# comment: no comment\n" "A,aux,B\n" "A.1,D,A.2\n")
         with pytest.raises(
             ValueError, match="Last column must be 'comment', but isn't."
         ):

--- a/climate_categories/tests/test_conversions.py
+++ b/climate_categories/tests/test_conversions.py
@@ -221,7 +221,7 @@ class TestConversionSpec:
             "A,species,B,comment\n"
             "A.1+,something,C,broken formula\n"
         )
-        with pytest.raises(ValueError, match="line 2.*Could not parse"):
+        with pytest.raises(ValueError, match="line 3.*Could not parse"):
             climate_categories._conversions.ConversionSpec.from_csv(csv)
 
     def test_unknown_meta_data(self):

--- a/climate_categories/tests/test_conversions.py
+++ b/climate_categories/tests/test_conversions.py
@@ -302,6 +302,16 @@ class TestConversion:
     def test_repr(self, good_conversion: conversions.Conversion):
         assert repr(good_conversion) == "<Conversion 'A' <-> 'B' with 9 rules>"
 
+    def test_not_allowed(self):
+        with pytest.raises(ValueError, match="Error in line 10: Could not parse:"):
+            load_conversion_from_csv("broken_conversion_not_allowed.csv")
+
+    def test_not_existing(self):
+        with pytest.raises(
+            ValueError, match="Error in line 10: 'notexisting' not in A"
+        ):
+            load_conversion_from_csv("broken_conversion_not_existing.csv")
+
     def test_describe(self, good_conversion: conversions.Conversion):
 
         assert (

--- a/climate_categories/tests/test_conversions.py
+++ b/climate_categories/tests/test_conversions.py
@@ -6,6 +6,7 @@ import importlib.resources
 from io import StringIO
 
 import pytest
+import strictyaml as sy
 
 import climate_categories
 import climate_categories._conversions as conversions
@@ -141,7 +142,7 @@ class TestConversionSpec:
         assert conv.comment == "A correct conversion specification file"
         assert conv.version == "1.2.3.4"
         assert conv.references == "expert judgement"
-        assert conv.last_update == datetime.date(2099, 12, 31)
+        assert conv.last_update == datetime.datetime(2099, 12, 31, 0, 0)
         assert conv.auxiliary_categorizations_names == ["aux1", "aux2"]
         assert len(conv.rule_specs) == 9
         assert conv.rule_specs[0] == conversions.ConversionRuleSpec(
@@ -228,9 +229,7 @@ class TestConversionSpec:
             "# comment: no comment\n"
             "# interjection: What you guys are referring to as Linux\n"
         )
-        with pytest.raises(
-            ValueError, match="Unknown meta data key in line 2: interjection"
-        ):
+        with pytest.raises(sy.exceptions.YAMLValidationError):
             climate_categories._conversions.ConversionSpec.from_csv(csv)
 
     def test_comment_missing(self):

--- a/climate_categories/tests/test_conversions.py
+++ b/climate_categories/tests/test_conversions.py
@@ -234,7 +234,6 @@ class TestConversionSpec:
             climate_categories._conversions.ConversionSpec.from_csv(csv)
 
     def test_comment_missing(self):
-        # csv = ["comment: no comment", "A,aux,B", "A.1,D,A.2"]
         csv = StringIO("# comment: no comment\n" "A,aux,B\n" "A.1,D,A.2\n")
         with pytest.raises(
             ValueError, match="Last column must be 'comment', but isn't."

--- a/docs/changelog_unreleased/metadata-format.rst
+++ b/docs/changelog_unreleased/metadata-format.rst
@@ -1,0 +1,1 @@
+* Change conversion metadata format to use comment chars and a YAML header.

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -185,8 +185,8 @@ Example
 
 .. code-block:: csv
 
-    comment: an example conversion
-    institution: PIK
+    # comment: an example conversion
+    # institution: PIK
     IPCC1996,gas,IPCC2006,comment
     4 + 5,,3,Both sectors were combined
     4.D,N2O,3.C.4 + 3.C.5,N2O emissions are separated into own categories

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -137,15 +137,15 @@ separated value files with a tightly specified format.
 Commas separate fields, and can be escaped using a backslash.
 Two consecutive backslashes are read as a single backslash.
 
-The file consists of a meta data block at the start of the file, and a data block
+The file consists of a YAML meta data block at the start of the file, and a data block
 following it.
-The two blocks are separated by an empty line.
+The YAML meta data block lines start with the commnet char '#'.
 
 Meta data block
 ---------------
 
 The meta data bloc consists of key-value pairs, one on each line, key and value
-separated by a comma.
+separated by a colon.
 All meta data are optional, the allowed keys are:
 
 ============  ====  ==========================================  ========================================
@@ -185,9 +185,8 @@ Example
 
 .. code-block:: csv
 
-    comment,an example conversion
-    institution,PIK
-
+    comment: an example conversion
+    institution: PIK
     IPCC1996,gas,IPCC2006,comment
     4 + 5,,3,Both sectors were combined
     4.D,N2O,3.C.4 + 3.C.5,N2O emissions are separated into own categories

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -139,7 +139,7 @@ Two consecutive backslashes are read as a single backslash.
 
 The file consists of a YAML meta data block at the start of the file, and a data block
 following it.
-The YAML meta data block lines start with the commnet char '#'.
+The YAML meta data block lines start with the comment char '#'.
 
 Meta data block
 ---------------


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests updated
- [x] Documentation updated
- [x] Changelog snippet in a ``.rst`` file in the directory ``changelog_unreleased`` added – remember to start with a ``*`` to make it a bullet point

## Description

Changes the metadata format for conversions as discussed in #48 

```
# references: "IPCC 2006, 2006 IPCC Guidelines for National Greenhouse Gas Inventories, Prepared by the National Greenhouse Gas Inventories Programme, Eggleston H.S., Buendia L., Miwa K., Ngara T. and Tanabe K. (eds). Volume 1, Chapter 8, Table 8.2 https://www.ipcc-nggip.iges.or.jp/public/2006gl/vol1.html"
# institution: IPCC
# last_update: 2021-07-09
IPCC1996,gas,IPCC2006,comment
0,,0,
1,,1,
1.A,,1.A,
1.A.1,,1.A.1,
```

