### PR TITLE
New unfccc di api

### DIFF
--- a/changelog_unreleased/new-unfccc-di-api.rst
+++ b/changelog_unreleased/new-unfccc-di-api.rst
@@ -1,0 +1,2 @@
+* The unfccc DI API recently returns unspecified measure IDs.
+  data_generation/CRFDI_class.py was fixed to ignore them.

--- a/data_generation/CRFDI_class.py
+++ b/data_generation/CRFDI_class.py
@@ -4,6 +4,7 @@ import datetime
 import pathlib
 
 import numpy as np
+import treelib
 import unfccc_di_api
 
 import climate_categories
@@ -80,7 +81,10 @@ def parse_refrigerant_measures(rao: unfccc_di_api.UNFCCCSingleCategoryApiReader)
 
         new_children_for_category = []
         for mid in sorted(measure_ids):
-            measure = rao.measure_tree[mid].tag
+            try:
+                measure = rao.measure_tree[mid].tag
+            except treelib.tree.NodeIDAbsentError:
+                continue
             if measure not in refrigerant_emission_measures:
                 continue
             short_mid = refrigerant_emission_measures[measure]

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ dev =
     xdoctest
     camelot-py[plot,cv]
     tox
-    unfccc_di_api
+    unfccc_di_api >= 3.0.1
     pygments-csv-lexer
     openscm-units
 


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog snippet in a ``.rst`` file in the directory ``changelog_unreleased`` added – remember to start with a ``*`` to make it a bullet point

## Description

The unfccc DI API recently returns unspecified measure IDs. `data_generation/CRFDI_class.py` was fixed to ignore them.
