### PR TITLE
Fix docs building

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.263'
+    rev: 'v0.0.265'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,8 @@ Copyright 2021, Potsdam-Institut für Klimafolgenforschung e.V.
 
 Copyright 2021, Robert Gieseke
 
+Copyright 2023, Climate Resource Pty Ltd
+
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 file except in compliance with the License. You may obtain a copy of the License at
 

--- a/changelog_unreleased/fix_docs_building.rst
+++ b/changelog_unreleased/fix_docs_building.rst
@@ -1,0 +1,1 @@
+* Remove pygments-csv-lexer dependency for docs building.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ release = climate_categories.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -104,7 +104,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ---------------------------------------

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -183,7 +183,7 @@ codes must be enclosed in ``"`` characters.
 Example
 -------
 
-.. code-block:: csv
+.. code-block:: yaml
 
     # comment: an example conversion
     # institution: PIK

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 .
 ipykernel
 nbsphinx
-pygments-csv-lexer

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,6 @@ dev =
     camelot-py[plot] >= 0.11.0
     tox
     unfccc_di_api >= 3.0.1
-    pygments-csv-lexer
     openscm-units
     black
 


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog snippet in a `.rst` file in the directory `changelog_unreleased` added – remember to start with a `*` to make it a bullet point

## Description

Remove pygments-csv-lexer dependency for docs building. Just highlighting the small CSV exqample we have as yaml is good enough, and the yaml lexer is built into pygments.