### PR TITLE
functions for calculating leaf children

### DIFF
--- a/changelog_unreleased/add-leaf-children.rst
+++ b/changelog_unreleased/add-leaf-children.rst
@@ -1,0 +1,2 @@
+* Add function to find leaf children of a category, useful for re-calculating top-level
+  categories from constituents.

--- a/climate_categories/tests/test_climate_categories.py
+++ b/climate_categories/tests/test_climate_categories.py
@@ -278,6 +278,20 @@ class TestHierarchical:
             HierCat["2B"],
         }
 
+        assert HierCat["1A"].is_leaf
+        assert not HierCat["1"].is_leaf
+        assert HierCat.is_leaf("3A")
+        assert HierCat.leaf_children("1") == [{HierCat["1A"], HierCat["1B"]}]
+        assert HierCat.leaf_children("0X3") == [
+            {HierCat["1A"], HierCat["1B"], HierCat["2A"], HierCat["2B"]}
+        ]
+        assert HierCat.leaf_children("0") == [
+            {HierCat["1A"], HierCat["1B"], HierCat["2A"], HierCat["2B"], HierCat["3A"]},
+            {HierCat["1A"], HierCat["1B"], HierCat["2A"], HierCat["2B"], HierCat["3A"]},
+            {HierCat["1A"], HierCat["1B"], HierCat["2A"], HierCat["2B"], HierCat["3A"]},
+        ]
+        assert HierCat.leaf_children("OT") == [{HierCat["1B"], HierCat["2B"]}]
+
         with pytest.raises(
             ValueError,
             match="'OT' is not a transitive child of the canonical top level '0'.",

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -381,6 +381,30 @@
   {
    "cell_type": "markdown",
    "source": [
+    "### Finding leaf descendants\n",
+    "\n",
+    "For purposes like re-calculating top-level categories from simple leaf categories, it\n",
+    "is useful to find the descendants of a category which have no children. Use the\n",
+    "`leaf_children` property to do so."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "HierEx[\"0\"].leaf_children"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
     "### Extending categorizations\n",
     "\n",
     "Often, you want to use a common categorization, but for one reason or\n",


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog snippet in a `.rst` file in the directory `changelog_unreleased` added – remember to start with a `*` to make it a bullet point

## Description

Add function to find leaf children of a category, useful for re-calculating top-level categories from constituents.

