### PR TITLE
fix: remove "v" from GCAM version in region names

### DIFF
--- a/changelog_unreleased/gcam-fix.rst
+++ b/changelog_unreleased/gcam-fix.rst
@@ -1,0 +1,1 @@
+ * ISO3_GCAM: Removed extraneous "v" from version specifications in region codes

--- a/climate_categories/data/ISO3_GCAM.py
+++ b/climate_categories/data/ISO3_GCAM.py
@@ -2042,9 +2042,9 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.1|Africa_Eastern": {
+        "GCAM 5.1|Africa_Eastern": {
             "title": "Africa_Eastern",
-            "comment": "Region 'Africa_Eastern' as defined in GCAM version v5.1",
+            "comment": "Region 'Africa_Eastern' as defined in GCAM version 5.1",
             "children": [
                 [
                     "BDI",
@@ -2063,21 +2063,21 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.1|Africa_Northern": {
+        "GCAM 5.1|Africa_Northern": {
             "title": "Africa_Northern",
-            "comment": "Region 'Africa_Northern' as defined in GCAM version v5.1",
+            "comment": "Region 'Africa_Northern' as defined in GCAM version 5.1",
             "children": [["DZA", "EGY", "ESH", "LBY", "MAR", "TUN"]],
         },
-        "GCAM v5.1|Africa_Southern": {
+        "GCAM 5.1|Africa_Southern": {
             "title": "Africa_Southern",
-            "comment": "Region 'Africa_Southern' as defined in GCAM version v5.1",
+            "comment": "Region 'Africa_Southern' as defined in GCAM version 5.1",
             "children": [
                 ["AGO", "BWA", "LSO", "MOZ", "MWI", "NAM", "SWZ", "TZA", "ZMB", "ZWE"]
             ],
         },
-        "GCAM v5.1|Africa_Western": {
+        "GCAM 5.1|Africa_Western": {
             "title": "Africa_Western",
-            "comment": "Region 'Africa_Western' as defined in GCAM version v5.1",
+            "comment": "Region 'Africa_Western' as defined in GCAM version 5.1",
             "children": [
                 [
                     "BEN",
@@ -2107,29 +2107,29 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.1|Argentina": {
+        "GCAM 5.1|Argentina": {
             "title": "Argentina",
-            "comment": "Region 'Argentina' as defined in GCAM version v5.1",
+            "comment": "Region 'Argentina' as defined in GCAM version 5.1",
             "children": [["ARG"]],
         },
-        "GCAM v5.1|Australia_NZ": {
+        "GCAM 5.1|Australia_NZ": {
             "title": "Australia_NZ",
-            "comment": "Region 'Australia_NZ' as defined in GCAM version v5.1",
+            "comment": "Region 'Australia_NZ' as defined in GCAM version 5.1",
             "children": [["AUS", "NZL"]],
         },
-        "GCAM v5.1|Brazil": {
+        "GCAM 5.1|Brazil": {
             "title": "Brazil",
-            "comment": "Region 'Brazil' as defined in GCAM version v5.1",
+            "comment": "Region 'Brazil' as defined in GCAM version 5.1",
             "children": [["BRA"]],
         },
-        "GCAM v5.1|Canada": {
+        "GCAM 5.1|Canada": {
             "title": "Canada",
-            "comment": "Region 'Canada' as defined in GCAM version v5.1",
+            "comment": "Region 'Canada' as defined in GCAM version 5.1",
             "children": [["CAN"]],
         },
-        "GCAM v5.1|Central America and the Caribbean": {
+        "GCAM 5.1|Central America and the Caribbean": {
             "title": "Central America and the Caribbean",
-            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version v5.1",
+            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version 5.1",
             "children": [
                 [
                     "ABW",
@@ -2162,26 +2162,26 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.1|Central Asia": {
+        "GCAM 5.1|Central Asia": {
             "title": "Central Asia",
-            "comment": "Region 'Central Asia' as defined in GCAM version v5.1",
+            "comment": "Region 'Central Asia' as defined in GCAM version 5.1",
             "children": [
                 ["ARM", "AZE", "GEO", "KAZ", "KGZ", "MNG", "TJK", "TKM", "UZB"]
             ],
         },
-        "GCAM v5.1|China": {
+        "GCAM 5.1|China": {
             "title": "China",
-            "comment": "Region 'China' as defined in GCAM version v5.1",
+            "comment": "Region 'China' as defined in GCAM version 5.1",
             "children": [["CHN"]],
         },
-        "GCAM v5.1|Colombia": {
+        "GCAM 5.1|Colombia": {
             "title": "Colombia",
-            "comment": "Region 'Colombia' as defined in GCAM version v5.1",
+            "comment": "Region 'Colombia' as defined in GCAM version 5.1",
             "children": [["COL"]],
         },
-        "GCAM v5.1|EU-12": {
+        "GCAM 5.1|EU-12": {
             "title": "EU-12",
-            "comment": "Region 'EU-12' as defined in GCAM version v5.1",
+            "comment": "Region 'EU-12' as defined in GCAM version 5.1",
             "children": [
                 [
                     "BGR",
@@ -2199,9 +2199,9 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.1|EU-15": {
+        "GCAM 5.1|EU-15": {
             "title": "EU-15",
-            "comment": "Region 'EU-15' as defined in GCAM version v5.1",
+            "comment": "Region 'EU-15' as defined in GCAM version 5.1",
             "children": [
                 [
                     "AND",
@@ -2225,44 +2225,44 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.1|Europe_Eastern": {
+        "GCAM 5.1|Europe_Eastern": {
             "title": "Europe_Eastern",
-            "comment": "Region 'Europe_Eastern' as defined in GCAM version v5.1",
+            "comment": "Region 'Europe_Eastern' as defined in GCAM version 5.1",
             "children": [["BLR", "MDA", "UKR"]],
         },
-        "GCAM v5.1|European Free Trade Association": {
+        "GCAM 5.1|European Free Trade Association": {
             "title": "European Free Trade Association",
-            "comment": "Region 'European Free Trade Association' as defined in GCAM version v5.1",
+            "comment": "Region 'European Free Trade Association' as defined in GCAM version 5.1",
             "children": [["CHE", "ISL", "NOR"]],
         },
-        "GCAM v5.1|Europe_Non_EU": {
+        "GCAM 5.1|Europe_Non_EU": {
             "title": "Europe_Non_EU",
-            "comment": "Region 'Europe_Non_EU' as defined in GCAM version v5.1",
+            "comment": "Region 'Europe_Non_EU' as defined in GCAM version 5.1",
             "children": [["ALB", "BIH", "HRV", "MKD", "MNE", "SRB", "TUR"]],
         },
-        "GCAM v5.1|India": {
+        "GCAM 5.1|India": {
             "title": "India",
-            "comment": "Region 'India' as defined in GCAM version v5.1",
+            "comment": "Region 'India' as defined in GCAM version 5.1",
             "children": [["IND"]],
         },
-        "GCAM v5.1|Indonesia": {
+        "GCAM 5.1|Indonesia": {
             "title": "Indonesia",
-            "comment": "Region 'Indonesia' as defined in GCAM version v5.1",
+            "comment": "Region 'Indonesia' as defined in GCAM version 5.1",
             "children": [["IDN"]],
         },
-        "GCAM v5.1|Japan": {
+        "GCAM 5.1|Japan": {
             "title": "Japan",
-            "comment": "Region 'Japan' as defined in GCAM version v5.1",
+            "comment": "Region 'Japan' as defined in GCAM version 5.1",
             "children": [["JPN"]],
         },
-        "GCAM v5.1|Mexico": {
+        "GCAM 5.1|Mexico": {
             "title": "Mexico",
-            "comment": "Region 'Mexico' as defined in GCAM version v5.1",
+            "comment": "Region 'Mexico' as defined in GCAM version 5.1",
             "children": [["MEX"]],
         },
-        "GCAM v5.1|Middle East": {
+        "GCAM 5.1|Middle East": {
             "title": "Middle East",
-            "comment": "Region 'Middle East' as defined in GCAM version v5.1",
+            "comment": "Region 'Middle East' as defined in GCAM version 5.1",
             "children": [
                 [
                     "ARE",
@@ -2282,39 +2282,39 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.1|Pakistan": {
+        "GCAM 5.1|Pakistan": {
             "title": "Pakistan",
-            "comment": "Region 'Pakistan' as defined in GCAM version v5.1",
+            "comment": "Region 'Pakistan' as defined in GCAM version 5.1",
             "children": [["PAK"]],
         },
-        "GCAM v5.1|Russia": {
+        "GCAM 5.1|Russia": {
             "title": "Russia",
-            "comment": "Region 'Russia' as defined in GCAM version v5.1",
+            "comment": "Region 'Russia' as defined in GCAM version 5.1",
             "children": [["RUS"]],
         },
-        "GCAM v5.1|South Africa": {
+        "GCAM 5.1|South Africa": {
             "title": "South Africa",
-            "comment": "Region 'South Africa' as defined in GCAM version v5.1",
+            "comment": "Region 'South Africa' as defined in GCAM version 5.1",
             "children": [["ZAF"]],
         },
-        "GCAM v5.1|South America_Northern": {
+        "GCAM 5.1|South America_Northern": {
             "title": "South America_Northern",
-            "comment": "Region 'South America_Northern' as defined in GCAM version v5.1",
+            "comment": "Region 'South America_Northern' as defined in GCAM version 5.1",
             "children": [["GUF", "GUY", "SUR", "VEN"]],
         },
-        "GCAM v5.1|South America_Southern": {
+        "GCAM 5.1|South America_Southern": {
             "title": "South America_Southern",
-            "comment": "Region 'South America_Southern' as defined in GCAM version v5.1",
+            "comment": "Region 'South America_Southern' as defined in GCAM version 5.1",
             "children": [["BOL", "CHL", "ECU", "PER", "PRY", "URY"]],
         },
-        "GCAM v5.1|South Asia": {
+        "GCAM 5.1|South Asia": {
             "title": "South Asia",
-            "comment": "Region 'South Asia' as defined in GCAM version v5.1",
+            "comment": "Region 'South Asia' as defined in GCAM version 5.1",
             "children": [["AFG", "BGD", "BTN", "LKA", "MDV", "NPL"]],
         },
-        "GCAM v5.1|Southeast Asia": {
+        "GCAM 5.1|Southeast Asia": {
             "title": "Southeast Asia",
-            "comment": "Region 'Southeast Asia' as defined in GCAM version v5.1",
+            "comment": "Region 'Southeast Asia' as defined in GCAM version 5.1",
             "children": [
                 [
                     "ASM",
@@ -2357,24 +2357,24 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.1|South Korea": {
+        "GCAM 5.1|South Korea": {
             "title": "South Korea",
-            "comment": "Region 'South Korea' as defined in GCAM version v5.1",
+            "comment": "Region 'South Korea' as defined in GCAM version 5.1",
             "children": [["KOR"]],
         },
-        "GCAM v5.1|Taiwan": {
+        "GCAM 5.1|Taiwan": {
             "title": "Taiwan",
-            "comment": "Region 'Taiwan' as defined in GCAM version v5.1",
+            "comment": "Region 'Taiwan' as defined in GCAM version 5.1",
             "children": [["TWN"]],
         },
-        "GCAM v5.1|USA": {
+        "GCAM 5.1|USA": {
             "title": "USA",
-            "comment": "Region 'USA' as defined in GCAM version v5.1",
+            "comment": "Region 'USA' as defined in GCAM version 5.1",
             "children": [["USA"]],
         },
-        "GCAM v5.2|Africa_Eastern": {
+        "GCAM 5.2|Africa_Eastern": {
             "title": "Africa_Eastern",
-            "comment": "Region 'Africa_Eastern' as defined in GCAM version v5.2",
+            "comment": "Region 'Africa_Eastern' as defined in GCAM version 5.2",
             "children": [
                 [
                     "BDI",
@@ -2393,21 +2393,21 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.2|Africa_Northern": {
+        "GCAM 5.2|Africa_Northern": {
             "title": "Africa_Northern",
-            "comment": "Region 'Africa_Northern' as defined in GCAM version v5.2",
+            "comment": "Region 'Africa_Northern' as defined in GCAM version 5.2",
             "children": [["DZA", "EGY", "ESH", "LBY", "MAR", "TUN"]],
         },
-        "GCAM v5.2|Africa_Southern": {
+        "GCAM 5.2|Africa_Southern": {
             "title": "Africa_Southern",
-            "comment": "Region 'Africa_Southern' as defined in GCAM version v5.2",
+            "comment": "Region 'Africa_Southern' as defined in GCAM version 5.2",
             "children": [
                 ["AGO", "BWA", "LSO", "MOZ", "MWI", "NAM", "SWZ", "TZA", "ZMB", "ZWE"]
             ],
         },
-        "GCAM v5.2|Africa_Western": {
+        "GCAM 5.2|Africa_Western": {
             "title": "Africa_Western",
-            "comment": "Region 'Africa_Western' as defined in GCAM version v5.2",
+            "comment": "Region 'Africa_Western' as defined in GCAM version 5.2",
             "children": [
                 [
                     "BEN",
@@ -2437,29 +2437,29 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.2|Argentina": {
+        "GCAM 5.2|Argentina": {
             "title": "Argentina",
-            "comment": "Region 'Argentina' as defined in GCAM version v5.2",
+            "comment": "Region 'Argentina' as defined in GCAM version 5.2",
             "children": [["ARG"]],
         },
-        "GCAM v5.2|Australia_NZ": {
+        "GCAM 5.2|Australia_NZ": {
             "title": "Australia_NZ",
-            "comment": "Region 'Australia_NZ' as defined in GCAM version v5.2",
+            "comment": "Region 'Australia_NZ' as defined in GCAM version 5.2",
             "children": [["AUS", "NZL"]],
         },
-        "GCAM v5.2|Brazil": {
+        "GCAM 5.2|Brazil": {
             "title": "Brazil",
-            "comment": "Region 'Brazil' as defined in GCAM version v5.2",
+            "comment": "Region 'Brazil' as defined in GCAM version 5.2",
             "children": [["BRA"]],
         },
-        "GCAM v5.2|Canada": {
+        "GCAM 5.2|Canada": {
             "title": "Canada",
-            "comment": "Region 'Canada' as defined in GCAM version v5.2",
+            "comment": "Region 'Canada' as defined in GCAM version 5.2",
             "children": [["CAN"]],
         },
-        "GCAM v5.2|Central America and the Caribbean": {
+        "GCAM 5.2|Central America and the Caribbean": {
             "title": "Central America and the Caribbean",
-            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version v5.2",
+            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version 5.2",
             "children": [
                 [
                     "ABW",
@@ -2492,26 +2492,26 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.2|Central Asia": {
+        "GCAM 5.2|Central Asia": {
             "title": "Central Asia",
-            "comment": "Region 'Central Asia' as defined in GCAM version v5.2",
+            "comment": "Region 'Central Asia' as defined in GCAM version 5.2",
             "children": [
                 ["ARM", "AZE", "GEO", "KAZ", "KGZ", "MNG", "TJK", "TKM", "UZB"]
             ],
         },
-        "GCAM v5.2|China": {
+        "GCAM 5.2|China": {
             "title": "China",
-            "comment": "Region 'China' as defined in GCAM version v5.2",
+            "comment": "Region 'China' as defined in GCAM version 5.2",
             "children": [["CHN"]],
         },
-        "GCAM v5.2|Colombia": {
+        "GCAM 5.2|Colombia": {
             "title": "Colombia",
-            "comment": "Region 'Colombia' as defined in GCAM version v5.2",
+            "comment": "Region 'Colombia' as defined in GCAM version 5.2",
             "children": [["COL"]],
         },
-        "GCAM v5.2|EU-12": {
+        "GCAM 5.2|EU-12": {
             "title": "EU-12",
-            "comment": "Region 'EU-12' as defined in GCAM version v5.2",
+            "comment": "Region 'EU-12' as defined in GCAM version 5.2",
             "children": [
                 [
                     "BGR",
@@ -2529,9 +2529,9 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.2|EU-15": {
+        "GCAM 5.2|EU-15": {
             "title": "EU-15",
-            "comment": "Region 'EU-15' as defined in GCAM version v5.2",
+            "comment": "Region 'EU-15' as defined in GCAM version 5.2",
             "children": [
                 [
                     "AND",
@@ -2555,44 +2555,44 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.2|Europe_Eastern": {
+        "GCAM 5.2|Europe_Eastern": {
             "title": "Europe_Eastern",
-            "comment": "Region 'Europe_Eastern' as defined in GCAM version v5.2",
+            "comment": "Region 'Europe_Eastern' as defined in GCAM version 5.2",
             "children": [["BLR", "MDA", "UKR"]],
         },
-        "GCAM v5.2|European Free Trade Association": {
+        "GCAM 5.2|European Free Trade Association": {
             "title": "European Free Trade Association",
-            "comment": "Region 'European Free Trade Association' as defined in GCAM version v5.2",
+            "comment": "Region 'European Free Trade Association' as defined in GCAM version 5.2",
             "children": [["CHE", "ISL", "NOR"]],
         },
-        "GCAM v5.2|Europe_Non_EU": {
+        "GCAM 5.2|Europe_Non_EU": {
             "title": "Europe_Non_EU",
-            "comment": "Region 'Europe_Non_EU' as defined in GCAM version v5.2",
+            "comment": "Region 'Europe_Non_EU' as defined in GCAM version 5.2",
             "children": [["ALB", "BIH", "HRV", "MKD", "MNE", "SRB", "TUR"]],
         },
-        "GCAM v5.2|India": {
+        "GCAM 5.2|India": {
             "title": "India",
-            "comment": "Region 'India' as defined in GCAM version v5.2",
+            "comment": "Region 'India' as defined in GCAM version 5.2",
             "children": [["IND"]],
         },
-        "GCAM v5.2|Indonesia": {
+        "GCAM 5.2|Indonesia": {
             "title": "Indonesia",
-            "comment": "Region 'Indonesia' as defined in GCAM version v5.2",
+            "comment": "Region 'Indonesia' as defined in GCAM version 5.2",
             "children": [["IDN"]],
         },
-        "GCAM v5.2|Japan": {
+        "GCAM 5.2|Japan": {
             "title": "Japan",
-            "comment": "Region 'Japan' as defined in GCAM version v5.2",
+            "comment": "Region 'Japan' as defined in GCAM version 5.2",
             "children": [["JPN"]],
         },
-        "GCAM v5.2|Mexico": {
+        "GCAM 5.2|Mexico": {
             "title": "Mexico",
-            "comment": "Region 'Mexico' as defined in GCAM version v5.2",
+            "comment": "Region 'Mexico' as defined in GCAM version 5.2",
             "children": [["MEX"]],
         },
-        "GCAM v5.2|Middle East": {
+        "GCAM 5.2|Middle East": {
             "title": "Middle East",
-            "comment": "Region 'Middle East' as defined in GCAM version v5.2",
+            "comment": "Region 'Middle East' as defined in GCAM version 5.2",
             "children": [
                 [
                     "ARE",
@@ -2612,39 +2612,39 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.2|Pakistan": {
+        "GCAM 5.2|Pakistan": {
             "title": "Pakistan",
-            "comment": "Region 'Pakistan' as defined in GCAM version v5.2",
+            "comment": "Region 'Pakistan' as defined in GCAM version 5.2",
             "children": [["PAK"]],
         },
-        "GCAM v5.2|Russia": {
+        "GCAM 5.2|Russia": {
             "title": "Russia",
-            "comment": "Region 'Russia' as defined in GCAM version v5.2",
+            "comment": "Region 'Russia' as defined in GCAM version 5.2",
             "children": [["RUS"]],
         },
-        "GCAM v5.2|South Africa": {
+        "GCAM 5.2|South Africa": {
             "title": "South Africa",
-            "comment": "Region 'South Africa' as defined in GCAM version v5.2",
+            "comment": "Region 'South Africa' as defined in GCAM version 5.2",
             "children": [["ZAF"]],
         },
-        "GCAM v5.2|South America_Northern": {
+        "GCAM 5.2|South America_Northern": {
             "title": "South America_Northern",
-            "comment": "Region 'South America_Northern' as defined in GCAM version v5.2",
+            "comment": "Region 'South America_Northern' as defined in GCAM version 5.2",
             "children": [["GUF", "GUY", "SUR", "VEN"]],
         },
-        "GCAM v5.2|South America_Southern": {
+        "GCAM 5.2|South America_Southern": {
             "title": "South America_Southern",
-            "comment": "Region 'South America_Southern' as defined in GCAM version v5.2",
+            "comment": "Region 'South America_Southern' as defined in GCAM version 5.2",
             "children": [["BOL", "CHL", "ECU", "PER", "PRY", "URY"]],
         },
-        "GCAM v5.2|South Asia": {
+        "GCAM 5.2|South Asia": {
             "title": "South Asia",
-            "comment": "Region 'South Asia' as defined in GCAM version v5.2",
+            "comment": "Region 'South Asia' as defined in GCAM version 5.2",
             "children": [["AFG", "BGD", "BTN", "LKA", "MDV", "NPL"]],
         },
-        "GCAM v5.2|Southeast Asia": {
+        "GCAM 5.2|Southeast Asia": {
             "title": "Southeast Asia",
-            "comment": "Region 'Southeast Asia' as defined in GCAM version v5.2",
+            "comment": "Region 'Southeast Asia' as defined in GCAM version 5.2",
             "children": [
                 [
                     "ASM",
@@ -2687,24 +2687,24 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.2|South Korea": {
+        "GCAM 5.2|South Korea": {
             "title": "South Korea",
-            "comment": "Region 'South Korea' as defined in GCAM version v5.2",
+            "comment": "Region 'South Korea' as defined in GCAM version 5.2",
             "children": [["KOR"]],
         },
-        "GCAM v5.2|Taiwan": {
+        "GCAM 5.2|Taiwan": {
             "title": "Taiwan",
-            "comment": "Region 'Taiwan' as defined in GCAM version v5.2",
+            "comment": "Region 'Taiwan' as defined in GCAM version 5.2",
             "children": [["TWN"]],
         },
-        "GCAM v5.2|USA": {
+        "GCAM 5.2|USA": {
             "title": "USA",
-            "comment": "Region 'USA' as defined in GCAM version v5.2",
+            "comment": "Region 'USA' as defined in GCAM version 5.2",
             "children": [["USA"]],
         },
-        "GCAM v5.3|Africa_Eastern": {
+        "GCAM 5.3|Africa_Eastern": {
             "title": "Africa_Eastern",
-            "comment": "Region 'Africa_Eastern' as defined in GCAM version v5.3",
+            "comment": "Region 'Africa_Eastern' as defined in GCAM version 5.3",
             "children": [
                 [
                     "BDI",
@@ -2723,21 +2723,21 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.3|Africa_Northern": {
+        "GCAM 5.3|Africa_Northern": {
             "title": "Africa_Northern",
-            "comment": "Region 'Africa_Northern' as defined in GCAM version v5.3",
+            "comment": "Region 'Africa_Northern' as defined in GCAM version 5.3",
             "children": [["DZA", "EGY", "ESH", "LBY", "MAR", "TUN"]],
         },
-        "GCAM v5.3|Africa_Southern": {
+        "GCAM 5.3|Africa_Southern": {
             "title": "Africa_Southern",
-            "comment": "Region 'Africa_Southern' as defined in GCAM version v5.3",
+            "comment": "Region 'Africa_Southern' as defined in GCAM version 5.3",
             "children": [
                 ["AGO", "BWA", "LSO", "MOZ", "MWI", "NAM", "SWZ", "TZA", "ZMB", "ZWE"]
             ],
         },
-        "GCAM v5.3|Africa_Western": {
+        "GCAM 5.3|Africa_Western": {
             "title": "Africa_Western",
-            "comment": "Region 'Africa_Western' as defined in GCAM version v5.3",
+            "comment": "Region 'Africa_Western' as defined in GCAM version 5.3",
             "children": [
                 [
                     "BEN",
@@ -2767,29 +2767,29 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.3|Argentina": {
+        "GCAM 5.3|Argentina": {
             "title": "Argentina",
-            "comment": "Region 'Argentina' as defined in GCAM version v5.3",
+            "comment": "Region 'Argentina' as defined in GCAM version 5.3",
             "children": [["ARG"]],
         },
-        "GCAM v5.3|Australia_NZ": {
+        "GCAM 5.3|Australia_NZ": {
             "title": "Australia_NZ",
-            "comment": "Region 'Australia_NZ' as defined in GCAM version v5.3",
+            "comment": "Region 'Australia_NZ' as defined in GCAM version 5.3",
             "children": [["AUS", "NZL"]],
         },
-        "GCAM v5.3|Brazil": {
+        "GCAM 5.3|Brazil": {
             "title": "Brazil",
-            "comment": "Region 'Brazil' as defined in GCAM version v5.3",
+            "comment": "Region 'Brazil' as defined in GCAM version 5.3",
             "children": [["BRA"]],
         },
-        "GCAM v5.3|Canada": {
+        "GCAM 5.3|Canada": {
             "title": "Canada",
-            "comment": "Region 'Canada' as defined in GCAM version v5.3",
+            "comment": "Region 'Canada' as defined in GCAM version 5.3",
             "children": [["CAN"]],
         },
-        "GCAM v5.3|Central America and the Caribbean": {
+        "GCAM 5.3|Central America and the Caribbean": {
             "title": "Central America and the Caribbean",
-            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version v5.3",
+            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version 5.3",
             "children": [
                 [
                     "ABW",
@@ -2822,26 +2822,26 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.3|Central Asia": {
+        "GCAM 5.3|Central Asia": {
             "title": "Central Asia",
-            "comment": "Region 'Central Asia' as defined in GCAM version v5.3",
+            "comment": "Region 'Central Asia' as defined in GCAM version 5.3",
             "children": [
                 ["ARM", "AZE", "GEO", "KAZ", "KGZ", "MNG", "TJK", "TKM", "UZB"]
             ],
         },
-        "GCAM v5.3|China": {
+        "GCAM 5.3|China": {
             "title": "China",
-            "comment": "Region 'China' as defined in GCAM version v5.3",
+            "comment": "Region 'China' as defined in GCAM version 5.3",
             "children": [["CHN"]],
         },
-        "GCAM v5.3|Colombia": {
+        "GCAM 5.3|Colombia": {
             "title": "Colombia",
-            "comment": "Region 'Colombia' as defined in GCAM version v5.3",
+            "comment": "Region 'Colombia' as defined in GCAM version 5.3",
             "children": [["COL"]],
         },
-        "GCAM v5.3|EU-12": {
+        "GCAM 5.3|EU-12": {
             "title": "EU-12",
-            "comment": "Region 'EU-12' as defined in GCAM version v5.3",
+            "comment": "Region 'EU-12' as defined in GCAM version 5.3",
             "children": [
                 [
                     "BGR",
@@ -2859,9 +2859,9 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.3|EU-15": {
+        "GCAM 5.3|EU-15": {
             "title": "EU-15",
-            "comment": "Region 'EU-15' as defined in GCAM version v5.3",
+            "comment": "Region 'EU-15' as defined in GCAM version 5.3",
             "children": [
                 [
                     "AND",
@@ -2885,44 +2885,44 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.3|Europe_Eastern": {
+        "GCAM 5.3|Europe_Eastern": {
             "title": "Europe_Eastern",
-            "comment": "Region 'Europe_Eastern' as defined in GCAM version v5.3",
+            "comment": "Region 'Europe_Eastern' as defined in GCAM version 5.3",
             "children": [["BLR", "MDA", "UKR"]],
         },
-        "GCAM v5.3|European Free Trade Association": {
+        "GCAM 5.3|European Free Trade Association": {
             "title": "European Free Trade Association",
-            "comment": "Region 'European Free Trade Association' as defined in GCAM version v5.3",
+            "comment": "Region 'European Free Trade Association' as defined in GCAM version 5.3",
             "children": [["CHE", "ISL", "NOR"]],
         },
-        "GCAM v5.3|Europe_Non_EU": {
+        "GCAM 5.3|Europe_Non_EU": {
             "title": "Europe_Non_EU",
-            "comment": "Region 'Europe_Non_EU' as defined in GCAM version v5.3",
+            "comment": "Region 'Europe_Non_EU' as defined in GCAM version 5.3",
             "children": [["ALB", "BIH", "HRV", "MKD", "MNE", "SRB", "TUR"]],
         },
-        "GCAM v5.3|India": {
+        "GCAM 5.3|India": {
             "title": "India",
-            "comment": "Region 'India' as defined in GCAM version v5.3",
+            "comment": "Region 'India' as defined in GCAM version 5.3",
             "children": [["IND"]],
         },
-        "GCAM v5.3|Indonesia": {
+        "GCAM 5.3|Indonesia": {
             "title": "Indonesia",
-            "comment": "Region 'Indonesia' as defined in GCAM version v5.3",
+            "comment": "Region 'Indonesia' as defined in GCAM version 5.3",
             "children": [["IDN"]],
         },
-        "GCAM v5.3|Japan": {
+        "GCAM 5.3|Japan": {
             "title": "Japan",
-            "comment": "Region 'Japan' as defined in GCAM version v5.3",
+            "comment": "Region 'Japan' as defined in GCAM version 5.3",
             "children": [["JPN"]],
         },
-        "GCAM v5.3|Mexico": {
+        "GCAM 5.3|Mexico": {
             "title": "Mexico",
-            "comment": "Region 'Mexico' as defined in GCAM version v5.3",
+            "comment": "Region 'Mexico' as defined in GCAM version 5.3",
             "children": [["MEX"]],
         },
-        "GCAM v5.3|Middle East": {
+        "GCAM 5.3|Middle East": {
             "title": "Middle East",
-            "comment": "Region 'Middle East' as defined in GCAM version v5.3",
+            "comment": "Region 'Middle East' as defined in GCAM version 5.3",
             "children": [
                 [
                     "ARE",
@@ -2942,39 +2942,39 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.3|Pakistan": {
+        "GCAM 5.3|Pakistan": {
             "title": "Pakistan",
-            "comment": "Region 'Pakistan' as defined in GCAM version v5.3",
+            "comment": "Region 'Pakistan' as defined in GCAM version 5.3",
             "children": [["PAK"]],
         },
-        "GCAM v5.3|Russia": {
+        "GCAM 5.3|Russia": {
             "title": "Russia",
-            "comment": "Region 'Russia' as defined in GCAM version v5.3",
+            "comment": "Region 'Russia' as defined in GCAM version 5.3",
             "children": [["RUS"]],
         },
-        "GCAM v5.3|South Africa": {
+        "GCAM 5.3|South Africa": {
             "title": "South Africa",
-            "comment": "Region 'South Africa' as defined in GCAM version v5.3",
+            "comment": "Region 'South Africa' as defined in GCAM version 5.3",
             "children": [["ZAF"]],
         },
-        "GCAM v5.3|South America_Northern": {
+        "GCAM 5.3|South America_Northern": {
             "title": "South America_Northern",
-            "comment": "Region 'South America_Northern' as defined in GCAM version v5.3",
+            "comment": "Region 'South America_Northern' as defined in GCAM version 5.3",
             "children": [["GUF", "GUY", "SUR", "VEN"]],
         },
-        "GCAM v5.3|South America_Southern": {
+        "GCAM 5.3|South America_Southern": {
             "title": "South America_Southern",
-            "comment": "Region 'South America_Southern' as defined in GCAM version v5.3",
+            "comment": "Region 'South America_Southern' as defined in GCAM version 5.3",
             "children": [["BOL", "CHL", "ECU", "PER", "PRY", "URY"]],
         },
-        "GCAM v5.3|South Asia": {
+        "GCAM 5.3|South Asia": {
             "title": "South Asia",
-            "comment": "Region 'South Asia' as defined in GCAM version v5.3",
+            "comment": "Region 'South Asia' as defined in GCAM version 5.3",
             "children": [["AFG", "BGD", "BTN", "LKA", "MDV", "NPL"]],
         },
-        "GCAM v5.3|Southeast Asia": {
+        "GCAM 5.3|Southeast Asia": {
             "title": "Southeast Asia",
-            "comment": "Region 'Southeast Asia' as defined in GCAM version v5.3",
+            "comment": "Region 'Southeast Asia' as defined in GCAM version 5.3",
             "children": [
                 [
                     "ASM",
@@ -3017,24 +3017,24 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.3|South Korea": {
+        "GCAM 5.3|South Korea": {
             "title": "South Korea",
-            "comment": "Region 'South Korea' as defined in GCAM version v5.3",
+            "comment": "Region 'South Korea' as defined in GCAM version 5.3",
             "children": [["KOR"]],
         },
-        "GCAM v5.3|Taiwan": {
+        "GCAM 5.3|Taiwan": {
             "title": "Taiwan",
-            "comment": "Region 'Taiwan' as defined in GCAM version v5.3",
+            "comment": "Region 'Taiwan' as defined in GCAM version 5.3",
             "children": [["TWN"]],
         },
-        "GCAM v5.3|USA": {
+        "GCAM 5.3|USA": {
             "title": "USA",
-            "comment": "Region 'USA' as defined in GCAM version v5.3",
+            "comment": "Region 'USA' as defined in GCAM version 5.3",
             "children": [["USA"]],
         },
-        "GCAM v5.4|Africa_Eastern": {
+        "GCAM 5.4|Africa_Eastern": {
             "title": "Africa_Eastern",
-            "comment": "Region 'Africa_Eastern' as defined in GCAM version v5.4",
+            "comment": "Region 'Africa_Eastern' as defined in GCAM version 5.4",
             "children": [
                 [
                     "BDI",
@@ -3053,21 +3053,21 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.4|Africa_Northern": {
+        "GCAM 5.4|Africa_Northern": {
             "title": "Africa_Northern",
-            "comment": "Region 'Africa_Northern' as defined in GCAM version v5.4",
+            "comment": "Region 'Africa_Northern' as defined in GCAM version 5.4",
             "children": [["DZA", "EGY", "ESH", "LBY", "MAR", "TUN"]],
         },
-        "GCAM v5.4|Africa_Southern": {
+        "GCAM 5.4|Africa_Southern": {
             "title": "Africa_Southern",
-            "comment": "Region 'Africa_Southern' as defined in GCAM version v5.4",
+            "comment": "Region 'Africa_Southern' as defined in GCAM version 5.4",
             "children": [
                 ["AGO", "BWA", "LSO", "MOZ", "MWI", "NAM", "SWZ", "TZA", "ZMB", "ZWE"]
             ],
         },
-        "GCAM v5.4|Africa_Western": {
+        "GCAM 5.4|Africa_Western": {
             "title": "Africa_Western",
-            "comment": "Region 'Africa_Western' as defined in GCAM version v5.4",
+            "comment": "Region 'Africa_Western' as defined in GCAM version 5.4",
             "children": [
                 [
                     "BEN",
@@ -3097,29 +3097,29 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.4|Argentina": {
+        "GCAM 5.4|Argentina": {
             "title": "Argentina",
-            "comment": "Region 'Argentina' as defined in GCAM version v5.4",
+            "comment": "Region 'Argentina' as defined in GCAM version 5.4",
             "children": [["ARG"]],
         },
-        "GCAM v5.4|Australia_NZ": {
+        "GCAM 5.4|Australia_NZ": {
             "title": "Australia_NZ",
-            "comment": "Region 'Australia_NZ' as defined in GCAM version v5.4",
+            "comment": "Region 'Australia_NZ' as defined in GCAM version 5.4",
             "children": [["AUS", "NZL"]],
         },
-        "GCAM v5.4|Brazil": {
+        "GCAM 5.4|Brazil": {
             "title": "Brazil",
-            "comment": "Region 'Brazil' as defined in GCAM version v5.4",
+            "comment": "Region 'Brazil' as defined in GCAM version 5.4",
             "children": [["BRA"]],
         },
-        "GCAM v5.4|Canada": {
+        "GCAM 5.4|Canada": {
             "title": "Canada",
-            "comment": "Region 'Canada' as defined in GCAM version v5.4",
+            "comment": "Region 'Canada' as defined in GCAM version 5.4",
             "children": [["CAN"]],
         },
-        "GCAM v5.4|Central America and the Caribbean": {
+        "GCAM 5.4|Central America and the Caribbean": {
             "title": "Central America and the Caribbean",
-            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version v5.4",
+            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version 5.4",
             "children": [
                 [
                     "ABW",
@@ -3152,26 +3152,26 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.4|Central Asia": {
+        "GCAM 5.4|Central Asia": {
             "title": "Central Asia",
-            "comment": "Region 'Central Asia' as defined in GCAM version v5.4",
+            "comment": "Region 'Central Asia' as defined in GCAM version 5.4",
             "children": [
                 ["ARM", "AZE", "GEO", "KAZ", "KGZ", "MNG", "TJK", "TKM", "UZB"]
             ],
         },
-        "GCAM v5.4|China": {
+        "GCAM 5.4|China": {
             "title": "China",
-            "comment": "Region 'China' as defined in GCAM version v5.4",
+            "comment": "Region 'China' as defined in GCAM version 5.4",
             "children": [["CHN"]],
         },
-        "GCAM v5.4|Colombia": {
+        "GCAM 5.4|Colombia": {
             "title": "Colombia",
-            "comment": "Region 'Colombia' as defined in GCAM version v5.4",
+            "comment": "Region 'Colombia' as defined in GCAM version 5.4",
             "children": [["COL"]],
         },
-        "GCAM v5.4|EU-12": {
+        "GCAM 5.4|EU-12": {
             "title": "EU-12",
-            "comment": "Region 'EU-12' as defined in GCAM version v5.4",
+            "comment": "Region 'EU-12' as defined in GCAM version 5.4",
             "children": [
                 [
                     "BGR",
@@ -3189,9 +3189,9 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.4|EU-15": {
+        "GCAM 5.4|EU-15": {
             "title": "EU-15",
-            "comment": "Region 'EU-15' as defined in GCAM version v5.4",
+            "comment": "Region 'EU-15' as defined in GCAM version 5.4",
             "children": [
                 [
                     "AND",
@@ -3215,44 +3215,44 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.4|Europe_Eastern": {
+        "GCAM 5.4|Europe_Eastern": {
             "title": "Europe_Eastern",
-            "comment": "Region 'Europe_Eastern' as defined in GCAM version v5.4",
+            "comment": "Region 'Europe_Eastern' as defined in GCAM version 5.4",
             "children": [["BLR", "MDA", "UKR"]],
         },
-        "GCAM v5.4|European Free Trade Association": {
+        "GCAM 5.4|European Free Trade Association": {
             "title": "European Free Trade Association",
-            "comment": "Region 'European Free Trade Association' as defined in GCAM version v5.4",
+            "comment": "Region 'European Free Trade Association' as defined in GCAM version 5.4",
             "children": [["CHE", "ISL", "NOR"]],
         },
-        "GCAM v5.4|Europe_Non_EU": {
+        "GCAM 5.4|Europe_Non_EU": {
             "title": "Europe_Non_EU",
-            "comment": "Region 'Europe_Non_EU' as defined in GCAM version v5.4",
+            "comment": "Region 'Europe_Non_EU' as defined in GCAM version 5.4",
             "children": [["ALB", "BIH", "HRV", "MKD", "MNE", "SRB", "TUR"]],
         },
-        "GCAM v5.4|India": {
+        "GCAM 5.4|India": {
             "title": "India",
-            "comment": "Region 'India' as defined in GCAM version v5.4",
+            "comment": "Region 'India' as defined in GCAM version 5.4",
             "children": [["IND"]],
         },
-        "GCAM v5.4|Indonesia": {
+        "GCAM 5.4|Indonesia": {
             "title": "Indonesia",
-            "comment": "Region 'Indonesia' as defined in GCAM version v5.4",
+            "comment": "Region 'Indonesia' as defined in GCAM version 5.4",
             "children": [["IDN"]],
         },
-        "GCAM v5.4|Japan": {
+        "GCAM 5.4|Japan": {
             "title": "Japan",
-            "comment": "Region 'Japan' as defined in GCAM version v5.4",
+            "comment": "Region 'Japan' as defined in GCAM version 5.4",
             "children": [["JPN"]],
         },
-        "GCAM v5.4|Mexico": {
+        "GCAM 5.4|Mexico": {
             "title": "Mexico",
-            "comment": "Region 'Mexico' as defined in GCAM version v5.4",
+            "comment": "Region 'Mexico' as defined in GCAM version 5.4",
             "children": [["MEX"]],
         },
-        "GCAM v5.4|Middle East": {
+        "GCAM 5.4|Middle East": {
             "title": "Middle East",
-            "comment": "Region 'Middle East' as defined in GCAM version v5.4",
+            "comment": "Region 'Middle East' as defined in GCAM version 5.4",
             "children": [
                 [
                     "ARE",
@@ -3272,39 +3272,39 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.4|Pakistan": {
+        "GCAM 5.4|Pakistan": {
             "title": "Pakistan",
-            "comment": "Region 'Pakistan' as defined in GCAM version v5.4",
+            "comment": "Region 'Pakistan' as defined in GCAM version 5.4",
             "children": [["PAK"]],
         },
-        "GCAM v5.4|Russia": {
+        "GCAM 5.4|Russia": {
             "title": "Russia",
-            "comment": "Region 'Russia' as defined in GCAM version v5.4",
+            "comment": "Region 'Russia' as defined in GCAM version 5.4",
             "children": [["RUS"]],
         },
-        "GCAM v5.4|South Africa": {
+        "GCAM 5.4|South Africa": {
             "title": "South Africa",
-            "comment": "Region 'South Africa' as defined in GCAM version v5.4",
+            "comment": "Region 'South Africa' as defined in GCAM version 5.4",
             "children": [["ZAF"]],
         },
-        "GCAM v5.4|South America_Northern": {
+        "GCAM 5.4|South America_Northern": {
             "title": "South America_Northern",
-            "comment": "Region 'South America_Northern' as defined in GCAM version v5.4",
+            "comment": "Region 'South America_Northern' as defined in GCAM version 5.4",
             "children": [["GUF", "GUY", "SUR", "VEN"]],
         },
-        "GCAM v5.4|South America_Southern": {
+        "GCAM 5.4|South America_Southern": {
             "title": "South America_Southern",
-            "comment": "Region 'South America_Southern' as defined in GCAM version v5.4",
+            "comment": "Region 'South America_Southern' as defined in GCAM version 5.4",
             "children": [["BOL", "CHL", "ECU", "PER", "PRY", "URY"]],
         },
-        "GCAM v5.4|South Asia": {
+        "GCAM 5.4|South Asia": {
             "title": "South Asia",
-            "comment": "Region 'South Asia' as defined in GCAM version v5.4",
+            "comment": "Region 'South Asia' as defined in GCAM version 5.4",
             "children": [["AFG", "BGD", "BTN", "LKA", "MDV", "NPL"]],
         },
-        "GCAM v5.4|Southeast Asia": {
+        "GCAM 5.4|Southeast Asia": {
             "title": "Southeast Asia",
-            "comment": "Region 'Southeast Asia' as defined in GCAM version v5.4",
+            "comment": "Region 'Southeast Asia' as defined in GCAM version 5.4",
             "children": [
                 [
                     "ASM",
@@ -3347,24 +3347,24 @@ spec = {
                 ]
             ],
         },
-        "GCAM v5.4|South Korea": {
+        "GCAM 5.4|South Korea": {
             "title": "South Korea",
-            "comment": "Region 'South Korea' as defined in GCAM version v5.4",
+            "comment": "Region 'South Korea' as defined in GCAM version 5.4",
             "children": [["KOR"]],
         },
-        "GCAM v5.4|Taiwan": {
+        "GCAM 5.4|Taiwan": {
             "title": "Taiwan",
-            "comment": "Region 'Taiwan' as defined in GCAM version v5.4",
+            "comment": "Region 'Taiwan' as defined in GCAM version 5.4",
             "children": [["TWN"]],
         },
-        "GCAM v5.4|USA": {
+        "GCAM 5.4|USA": {
             "title": "USA",
-            "comment": "Region 'USA' as defined in GCAM version v5.4",
+            "comment": "Region 'USA' as defined in GCAM version 5.4",
             "children": [["USA"]],
         },
-        "GCAM v6.0|Africa_Eastern": {
+        "GCAM 6.0|Africa_Eastern": {
             "title": "Africa_Eastern",
-            "comment": "Region 'Africa_Eastern' as defined in GCAM version v6.0",
+            "comment": "Region 'Africa_Eastern' as defined in GCAM version 6.0",
             "children": [
                 [
                     "BDI",
@@ -3383,21 +3383,21 @@ spec = {
                 ]
             ],
         },
-        "GCAM v6.0|Africa_Northern": {
+        "GCAM 6.0|Africa_Northern": {
             "title": "Africa_Northern",
-            "comment": "Region 'Africa_Northern' as defined in GCAM version v6.0",
+            "comment": "Region 'Africa_Northern' as defined in GCAM version 6.0",
             "children": [["DZA", "EGY", "ESH", "LBY", "MAR", "TUN"]],
         },
-        "GCAM v6.0|Africa_Southern": {
+        "GCAM 6.0|Africa_Southern": {
             "title": "Africa_Southern",
-            "comment": "Region 'Africa_Southern' as defined in GCAM version v6.0",
+            "comment": "Region 'Africa_Southern' as defined in GCAM version 6.0",
             "children": [
                 ["AGO", "BWA", "LSO", "MOZ", "MWI", "NAM", "SWZ", "TZA", "ZMB", "ZWE"]
             ],
         },
-        "GCAM v6.0|Africa_Western": {
+        "GCAM 6.0|Africa_Western": {
             "title": "Africa_Western",
-            "comment": "Region 'Africa_Western' as defined in GCAM version v6.0",
+            "comment": "Region 'Africa_Western' as defined in GCAM version 6.0",
             "children": [
                 [
                     "BEN",
@@ -3427,29 +3427,29 @@ spec = {
                 ]
             ],
         },
-        "GCAM v6.0|Argentina": {
+        "GCAM 6.0|Argentina": {
             "title": "Argentina",
-            "comment": "Region 'Argentina' as defined in GCAM version v6.0",
+            "comment": "Region 'Argentina' as defined in GCAM version 6.0",
             "children": [["ARG"]],
         },
-        "GCAM v6.0|Australia_NZ": {
+        "GCAM 6.0|Australia_NZ": {
             "title": "Australia_NZ",
-            "comment": "Region 'Australia_NZ' as defined in GCAM version v6.0",
+            "comment": "Region 'Australia_NZ' as defined in GCAM version 6.0",
             "children": [["AUS", "NZL"]],
         },
-        "GCAM v6.0|Brazil": {
+        "GCAM 6.0|Brazil": {
             "title": "Brazil",
-            "comment": "Region 'Brazil' as defined in GCAM version v6.0",
+            "comment": "Region 'Brazil' as defined in GCAM version 6.0",
             "children": [["BRA"]],
         },
-        "GCAM v6.0|Canada": {
+        "GCAM 6.0|Canada": {
             "title": "Canada",
-            "comment": "Region 'Canada' as defined in GCAM version v6.0",
+            "comment": "Region 'Canada' as defined in GCAM version 6.0",
             "children": [["CAN"]],
         },
-        "GCAM v6.0|Central America and the Caribbean": {
+        "GCAM 6.0|Central America and the Caribbean": {
             "title": "Central America and the Caribbean",
-            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version v6.0",
+            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version 6.0",
             "children": [
                 [
                     "ABW",
@@ -3482,26 +3482,26 @@ spec = {
                 ]
             ],
         },
-        "GCAM v6.0|Central Asia": {
+        "GCAM 6.0|Central Asia": {
             "title": "Central Asia",
-            "comment": "Region 'Central Asia' as defined in GCAM version v6.0",
+            "comment": "Region 'Central Asia' as defined in GCAM version 6.0",
             "children": [
                 ["ARM", "AZE", "GEO", "KAZ", "KGZ", "MNG", "TJK", "TKM", "UZB"]
             ],
         },
-        "GCAM v6.0|China": {
+        "GCAM 6.0|China": {
             "title": "China",
-            "comment": "Region 'China' as defined in GCAM version v6.0",
+            "comment": "Region 'China' as defined in GCAM version 6.0",
             "children": [["CHN"]],
         },
-        "GCAM v6.0|Colombia": {
+        "GCAM 6.0|Colombia": {
             "title": "Colombia",
-            "comment": "Region 'Colombia' as defined in GCAM version v6.0",
+            "comment": "Region 'Colombia' as defined in GCAM version 6.0",
             "children": [["COL"]],
         },
-        "GCAM v6.0|EU-12": {
+        "GCAM 6.0|EU-12": {
             "title": "EU-12",
-            "comment": "Region 'EU-12' as defined in GCAM version v6.0",
+            "comment": "Region 'EU-12' as defined in GCAM version 6.0",
             "children": [
                 [
                     "BGR",
@@ -3519,9 +3519,9 @@ spec = {
                 ]
             ],
         },
-        "GCAM v6.0|EU-15": {
+        "GCAM 6.0|EU-15": {
             "title": "EU-15",
-            "comment": "Region 'EU-15' as defined in GCAM version v6.0",
+            "comment": "Region 'EU-15' as defined in GCAM version 6.0",
             "children": [
                 [
                     "AND",
@@ -3545,44 +3545,44 @@ spec = {
                 ]
             ],
         },
-        "GCAM v6.0|Europe_Eastern": {
+        "GCAM 6.0|Europe_Eastern": {
             "title": "Europe_Eastern",
-            "comment": "Region 'Europe_Eastern' as defined in GCAM version v6.0",
+            "comment": "Region 'Europe_Eastern' as defined in GCAM version 6.0",
             "children": [["BLR", "MDA", "UKR"]],
         },
-        "GCAM v6.0|European Free Trade Association": {
+        "GCAM 6.0|European Free Trade Association": {
             "title": "European Free Trade Association",
-            "comment": "Region 'European Free Trade Association' as defined in GCAM version v6.0",
+            "comment": "Region 'European Free Trade Association' as defined in GCAM version 6.0",
             "children": [["CHE", "ISL", "NOR"]],
         },
-        "GCAM v6.0|Europe_Non_EU": {
+        "GCAM 6.0|Europe_Non_EU": {
             "title": "Europe_Non_EU",
-            "comment": "Region 'Europe_Non_EU' as defined in GCAM version v6.0",
+            "comment": "Region 'Europe_Non_EU' as defined in GCAM version 6.0",
             "children": [["ALB", "BIH", "HRV", "MKD", "MNE", "SRB", "TUR"]],
         },
-        "GCAM v6.0|India": {
+        "GCAM 6.0|India": {
             "title": "India",
-            "comment": "Region 'India' as defined in GCAM version v6.0",
+            "comment": "Region 'India' as defined in GCAM version 6.0",
             "children": [["IND"]],
         },
-        "GCAM v6.0|Indonesia": {
+        "GCAM 6.0|Indonesia": {
             "title": "Indonesia",
-            "comment": "Region 'Indonesia' as defined in GCAM version v6.0",
+            "comment": "Region 'Indonesia' as defined in GCAM version 6.0",
             "children": [["IDN"]],
         },
-        "GCAM v6.0|Japan": {
+        "GCAM 6.0|Japan": {
             "title": "Japan",
-            "comment": "Region 'Japan' as defined in GCAM version v6.0",
+            "comment": "Region 'Japan' as defined in GCAM version 6.0",
             "children": [["JPN"]],
         },
-        "GCAM v6.0|Mexico": {
+        "GCAM 6.0|Mexico": {
             "title": "Mexico",
-            "comment": "Region 'Mexico' as defined in GCAM version v6.0",
+            "comment": "Region 'Mexico' as defined in GCAM version 6.0",
             "children": [["MEX"]],
         },
-        "GCAM v6.0|Middle East": {
+        "GCAM 6.0|Middle East": {
             "title": "Middle East",
-            "comment": "Region 'Middle East' as defined in GCAM version v6.0",
+            "comment": "Region 'Middle East' as defined in GCAM version 6.0",
             "children": [
                 [
                     "ARE",
@@ -3602,39 +3602,39 @@ spec = {
                 ]
             ],
         },
-        "GCAM v6.0|Pakistan": {
+        "GCAM 6.0|Pakistan": {
             "title": "Pakistan",
-            "comment": "Region 'Pakistan' as defined in GCAM version v6.0",
+            "comment": "Region 'Pakistan' as defined in GCAM version 6.0",
             "children": [["PAK"]],
         },
-        "GCAM v6.0|Russia": {
+        "GCAM 6.0|Russia": {
             "title": "Russia",
-            "comment": "Region 'Russia' as defined in GCAM version v6.0",
+            "comment": "Region 'Russia' as defined in GCAM version 6.0",
             "children": [["RUS"]],
         },
-        "GCAM v6.0|South Africa": {
+        "GCAM 6.0|South Africa": {
             "title": "South Africa",
-            "comment": "Region 'South Africa' as defined in GCAM version v6.0",
+            "comment": "Region 'South Africa' as defined in GCAM version 6.0",
             "children": [["ZAF"]],
         },
-        "GCAM v6.0|South America_Northern": {
+        "GCAM 6.0|South America_Northern": {
             "title": "South America_Northern",
-            "comment": "Region 'South America_Northern' as defined in GCAM version v6.0",
+            "comment": "Region 'South America_Northern' as defined in GCAM version 6.0",
             "children": [["GUF", "GUY", "SUR", "VEN"]],
         },
-        "GCAM v6.0|South America_Southern": {
+        "GCAM 6.0|South America_Southern": {
             "title": "South America_Southern",
-            "comment": "Region 'South America_Southern' as defined in GCAM version v6.0",
+            "comment": "Region 'South America_Southern' as defined in GCAM version 6.0",
             "children": [["BOL", "CHL", "ECU", "PER", "PRY", "URY"]],
         },
-        "GCAM v6.0|South Asia": {
+        "GCAM 6.0|South Asia": {
             "title": "South Asia",
-            "comment": "Region 'South Asia' as defined in GCAM version v6.0",
+            "comment": "Region 'South Asia' as defined in GCAM version 6.0",
             "children": [["AFG", "BGD", "BTN", "LKA", "MDV", "NPL"]],
         },
-        "GCAM v6.0|Southeast Asia": {
+        "GCAM 6.0|Southeast Asia": {
             "title": "Southeast Asia",
-            "comment": "Region 'Southeast Asia' as defined in GCAM version v6.0",
+            "comment": "Region 'Southeast Asia' as defined in GCAM version 6.0",
             "children": [
                 [
                     "ASM",
@@ -3677,24 +3677,24 @@ spec = {
                 ]
             ],
         },
-        "GCAM v6.0|South Korea": {
+        "GCAM 6.0|South Korea": {
             "title": "South Korea",
-            "comment": "Region 'South Korea' as defined in GCAM version v6.0",
+            "comment": "Region 'South Korea' as defined in GCAM version 6.0",
             "children": [["KOR"]],
         },
-        "GCAM v6.0|Taiwan": {
+        "GCAM 6.0|Taiwan": {
             "title": "Taiwan",
-            "comment": "Region 'Taiwan' as defined in GCAM version v6.0",
+            "comment": "Region 'Taiwan' as defined in GCAM version 6.0",
             "children": [["TWN"]],
         },
-        "GCAM v6.0|USA": {
+        "GCAM 6.0|USA": {
             "title": "USA",
-            "comment": "Region 'USA' as defined in GCAM version v6.0",
+            "comment": "Region 'USA' as defined in GCAM version 6.0",
             "children": [["USA"]],
         },
-        "GCAM v7.0|Africa_Eastern": {
+        "GCAM 7.0|Africa_Eastern": {
             "title": "Africa_Eastern",
-            "comment": "Region 'Africa_Eastern' as defined in GCAM version v7.0",
+            "comment": "Region 'Africa_Eastern' as defined in GCAM version 7.0",
             "children": [
                 [
                     "BDI",
@@ -3713,21 +3713,21 @@ spec = {
                 ]
             ],
         },
-        "GCAM v7.0|Africa_Northern": {
+        "GCAM 7.0|Africa_Northern": {
             "title": "Africa_Northern",
-            "comment": "Region 'Africa_Northern' as defined in GCAM version v7.0",
+            "comment": "Region 'Africa_Northern' as defined in GCAM version 7.0",
             "children": [["DZA", "EGY", "ESH", "LBY", "MAR", "TUN"]],
         },
-        "GCAM v7.0|Africa_Southern": {
+        "GCAM 7.0|Africa_Southern": {
             "title": "Africa_Southern",
-            "comment": "Region 'Africa_Southern' as defined in GCAM version v7.0",
+            "comment": "Region 'Africa_Southern' as defined in GCAM version 7.0",
             "children": [
                 ["AGO", "BWA", "LSO", "MOZ", "MWI", "NAM", "SWZ", "TZA", "ZMB", "ZWE"]
             ],
         },
-        "GCAM v7.0|Africa_Western": {
+        "GCAM 7.0|Africa_Western": {
             "title": "Africa_Western",
-            "comment": "Region 'Africa_Western' as defined in GCAM version v7.0",
+            "comment": "Region 'Africa_Western' as defined in GCAM version 7.0",
             "children": [
                 [
                     "BEN",
@@ -3757,29 +3757,29 @@ spec = {
                 ]
             ],
         },
-        "GCAM v7.0|Argentina": {
+        "GCAM 7.0|Argentina": {
             "title": "Argentina",
-            "comment": "Region 'Argentina' as defined in GCAM version v7.0",
+            "comment": "Region 'Argentina' as defined in GCAM version 7.0",
             "children": [["ARG"]],
         },
-        "GCAM v7.0|Australia_NZ": {
+        "GCAM 7.0|Australia_NZ": {
             "title": "Australia_NZ",
-            "comment": "Region 'Australia_NZ' as defined in GCAM version v7.0",
+            "comment": "Region 'Australia_NZ' as defined in GCAM version 7.0",
             "children": [["AUS", "NZL"]],
         },
-        "GCAM v7.0|Brazil": {
+        "GCAM 7.0|Brazil": {
             "title": "Brazil",
-            "comment": "Region 'Brazil' as defined in GCAM version v7.0",
+            "comment": "Region 'Brazil' as defined in GCAM version 7.0",
             "children": [["BRA"]],
         },
-        "GCAM v7.0|Canada": {
+        "GCAM 7.0|Canada": {
             "title": "Canada",
-            "comment": "Region 'Canada' as defined in GCAM version v7.0",
+            "comment": "Region 'Canada' as defined in GCAM version 7.0",
             "children": [["CAN"]],
         },
-        "GCAM v7.0|Central America and the Caribbean": {
+        "GCAM 7.0|Central America and the Caribbean": {
             "title": "Central America and the Caribbean",
-            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version v7.0",
+            "comment": "Region 'Central America and the Caribbean' as defined in GCAM version 7.0",
             "children": [
                 [
                     "ABW",
@@ -3812,26 +3812,26 @@ spec = {
                 ]
             ],
         },
-        "GCAM v7.0|Central Asia": {
+        "GCAM 7.0|Central Asia": {
             "title": "Central Asia",
-            "comment": "Region 'Central Asia' as defined in GCAM version v7.0",
+            "comment": "Region 'Central Asia' as defined in GCAM version 7.0",
             "children": [
                 ["ARM", "AZE", "GEO", "KAZ", "KGZ", "MNG", "TJK", "TKM", "UZB"]
             ],
         },
-        "GCAM v7.0|China": {
+        "GCAM 7.0|China": {
             "title": "China",
-            "comment": "Region 'China' as defined in GCAM version v7.0",
+            "comment": "Region 'China' as defined in GCAM version 7.0",
             "children": [["CHN"]],
         },
-        "GCAM v7.0|Colombia": {
+        "GCAM 7.0|Colombia": {
             "title": "Colombia",
-            "comment": "Region 'Colombia' as defined in GCAM version v7.0",
+            "comment": "Region 'Colombia' as defined in GCAM version 7.0",
             "children": [["COL"]],
         },
-        "GCAM v7.0|EU-12": {
+        "GCAM 7.0|EU-12": {
             "title": "EU-12",
-            "comment": "Region 'EU-12' as defined in GCAM version v7.0",
+            "comment": "Region 'EU-12' as defined in GCAM version 7.0",
             "children": [
                 [
                     "BGR",
@@ -3849,9 +3849,9 @@ spec = {
                 ]
             ],
         },
-        "GCAM v7.0|EU-15": {
+        "GCAM 7.0|EU-15": {
             "title": "EU-15",
-            "comment": "Region 'EU-15' as defined in GCAM version v7.0",
+            "comment": "Region 'EU-15' as defined in GCAM version 7.0",
             "children": [
                 [
                     "AND",
@@ -3875,44 +3875,44 @@ spec = {
                 ]
             ],
         },
-        "GCAM v7.0|Europe_Eastern": {
+        "GCAM 7.0|Europe_Eastern": {
             "title": "Europe_Eastern",
-            "comment": "Region 'Europe_Eastern' as defined in GCAM version v7.0",
+            "comment": "Region 'Europe_Eastern' as defined in GCAM version 7.0",
             "children": [["BLR", "MDA", "UKR"]],
         },
-        "GCAM v7.0|European Free Trade Association": {
+        "GCAM 7.0|European Free Trade Association": {
             "title": "European Free Trade Association",
-            "comment": "Region 'European Free Trade Association' as defined in GCAM version v7.0",
+            "comment": "Region 'European Free Trade Association' as defined in GCAM version 7.0",
             "children": [["CHE", "ISL", "NOR"]],
         },
-        "GCAM v7.0|Europe_Non_EU": {
+        "GCAM 7.0|Europe_Non_EU": {
             "title": "Europe_Non_EU",
-            "comment": "Region 'Europe_Non_EU' as defined in GCAM version v7.0",
+            "comment": "Region 'Europe_Non_EU' as defined in GCAM version 7.0",
             "children": [["ALB", "BIH", "HRV", "MKD", "MNE", "SRB", "TUR"]],
         },
-        "GCAM v7.0|India": {
+        "GCAM 7.0|India": {
             "title": "India",
-            "comment": "Region 'India' as defined in GCAM version v7.0",
+            "comment": "Region 'India' as defined in GCAM version 7.0",
             "children": [["IND"]],
         },
-        "GCAM v7.0|Indonesia": {
+        "GCAM 7.0|Indonesia": {
             "title": "Indonesia",
-            "comment": "Region 'Indonesia' as defined in GCAM version v7.0",
+            "comment": "Region 'Indonesia' as defined in GCAM version 7.0",
             "children": [["IDN"]],
         },
-        "GCAM v7.0|Japan": {
+        "GCAM 7.0|Japan": {
             "title": "Japan",
-            "comment": "Region 'Japan' as defined in GCAM version v7.0",
+            "comment": "Region 'Japan' as defined in GCAM version 7.0",
             "children": [["JPN"]],
         },
-        "GCAM v7.0|Mexico": {
+        "GCAM 7.0|Mexico": {
             "title": "Mexico",
-            "comment": "Region 'Mexico' as defined in GCAM version v7.0",
+            "comment": "Region 'Mexico' as defined in GCAM version 7.0",
             "children": [["MEX"]],
         },
-        "GCAM v7.0|Middle East": {
+        "GCAM 7.0|Middle East": {
             "title": "Middle East",
-            "comment": "Region 'Middle East' as defined in GCAM version v7.0",
+            "comment": "Region 'Middle East' as defined in GCAM version 7.0",
             "children": [
                 [
                     "ARE",
@@ -3932,39 +3932,39 @@ spec = {
                 ]
             ],
         },
-        "GCAM v7.0|Pakistan": {
+        "GCAM 7.0|Pakistan": {
             "title": "Pakistan",
-            "comment": "Region 'Pakistan' as defined in GCAM version v7.0",
+            "comment": "Region 'Pakistan' as defined in GCAM version 7.0",
             "children": [["PAK"]],
         },
-        "GCAM v7.0|Russia": {
+        "GCAM 7.0|Russia": {
             "title": "Russia",
-            "comment": "Region 'Russia' as defined in GCAM version v7.0",
+            "comment": "Region 'Russia' as defined in GCAM version 7.0",
             "children": [["RUS"]],
         },
-        "GCAM v7.0|South Africa": {
+        "GCAM 7.0|South Africa": {
             "title": "South Africa",
-            "comment": "Region 'South Africa' as defined in GCAM version v7.0",
+            "comment": "Region 'South Africa' as defined in GCAM version 7.0",
             "children": [["ZAF"]],
         },
-        "GCAM v7.0|South America_Northern": {
+        "GCAM 7.0|South America_Northern": {
             "title": "South America_Northern",
-            "comment": "Region 'South America_Northern' as defined in GCAM version v7.0",
+            "comment": "Region 'South America_Northern' as defined in GCAM version 7.0",
             "children": [["GUF", "GUY", "SUR", "VEN"]],
         },
-        "GCAM v7.0|South America_Southern": {
+        "GCAM 7.0|South America_Southern": {
             "title": "South America_Southern",
-            "comment": "Region 'South America_Southern' as defined in GCAM version v7.0",
+            "comment": "Region 'South America_Southern' as defined in GCAM version 7.0",
             "children": [["BOL", "CHL", "ECU", "PER", "PRY", "URY"]],
         },
-        "GCAM v7.0|South Asia": {
+        "GCAM 7.0|South Asia": {
             "title": "South Asia",
-            "comment": "Region 'South Asia' as defined in GCAM version v7.0",
+            "comment": "Region 'South Asia' as defined in GCAM version 7.0",
             "children": [["AFG", "BGD", "BTN", "LKA", "MDV", "NPL"]],
         },
-        "GCAM v7.0|Southeast Asia": {
+        "GCAM 7.0|Southeast Asia": {
             "title": "Southeast Asia",
-            "comment": "Region 'Southeast Asia' as defined in GCAM version v7.0",
+            "comment": "Region 'Southeast Asia' as defined in GCAM version 7.0",
             "children": [
                 [
                     "ASM",
@@ -4007,19 +4007,19 @@ spec = {
                 ]
             ],
         },
-        "GCAM v7.0|South Korea": {
+        "GCAM 7.0|South Korea": {
             "title": "South Korea",
-            "comment": "Region 'South Korea' as defined in GCAM version v7.0",
+            "comment": "Region 'South Korea' as defined in GCAM version 7.0",
             "children": [["KOR"]],
         },
-        "GCAM v7.0|Taiwan": {
+        "GCAM 7.0|Taiwan": {
             "title": "Taiwan",
-            "comment": "Region 'Taiwan' as defined in GCAM version v7.0",
+            "comment": "Region 'Taiwan' as defined in GCAM version 7.0",
             "children": [["TWN"]],
         },
-        "GCAM v7.0|USA": {
+        "GCAM 7.0|USA": {
             "title": "USA",
-            "comment": "Region 'USA' as defined in GCAM version v7.0",
+            "comment": "Region 'USA' as defined in GCAM version 7.0",
             "children": [["USA"]],
         },
     },

--- a/climate_categories/data/ISO3_GCAM.yaml
+++ b/climate_categories/data/ISO3_GCAM.yaml
@@ -2614,9 +2614,9 @@ categories:
       - SWE
       - TUR
       - USA
-  GCAM v5.1|Africa_Eastern:
+  GCAM 5.1|Africa_Eastern:
     title: Africa_Eastern
-    comment: Region 'Africa_Eastern' as defined in GCAM version v5.1
+    comment: Region 'Africa_Eastern' as defined in GCAM version 5.1
     children:
     - - BDI
       - COM
@@ -2631,9 +2631,9 @@ categories:
       - SDN
       - SOM
       - UGA
-  GCAM v5.1|Africa_Northern:
+  GCAM 5.1|Africa_Northern:
     title: Africa_Northern
-    comment: Region 'Africa_Northern' as defined in GCAM version v5.1
+    comment: Region 'Africa_Northern' as defined in GCAM version 5.1
     children:
     - - DZA
       - EGY
@@ -2641,9 +2641,9 @@ categories:
       - LBY
       - MAR
       - TUN
-  GCAM v5.1|Africa_Southern:
+  GCAM 5.1|Africa_Southern:
     title: Africa_Southern
-    comment: Region 'Africa_Southern' as defined in GCAM version v5.1
+    comment: Region 'Africa_Southern' as defined in GCAM version 5.1
     children:
     - - AGO
       - BWA
@@ -2655,9 +2655,9 @@ categories:
       - TZA
       - ZMB
       - ZWE
-  GCAM v5.1|Africa_Western:
+  GCAM 5.1|Africa_Western:
     title: Africa_Western
-    comment: Region 'Africa_Western' as defined in GCAM version v5.1
+    comment: Region 'Africa_Western' as defined in GCAM version 5.1
     children:
     - - BEN
       - BFA
@@ -2683,31 +2683,31 @@ categories:
       - STP
       - TCD
       - TGO
-  GCAM v5.1|Argentina:
+  GCAM 5.1|Argentina:
     title: Argentina
-    comment: Region 'Argentina' as defined in GCAM version v5.1
+    comment: Region 'Argentina' as defined in GCAM version 5.1
     children:
     - - ARG
-  GCAM v5.1|Australia_NZ:
+  GCAM 5.1|Australia_NZ:
     title: Australia_NZ
-    comment: Region 'Australia_NZ' as defined in GCAM version v5.1
+    comment: Region 'Australia_NZ' as defined in GCAM version 5.1
     children:
     - - AUS
       - NZL
-  GCAM v5.1|Brazil:
+  GCAM 5.1|Brazil:
     title: Brazil
-    comment: Region 'Brazil' as defined in GCAM version v5.1
+    comment: Region 'Brazil' as defined in GCAM version 5.1
     children:
     - - BRA
-  GCAM v5.1|Canada:
+  GCAM 5.1|Canada:
     title: Canada
-    comment: Region 'Canada' as defined in GCAM version v5.1
+    comment: Region 'Canada' as defined in GCAM version 5.1
     children:
     - - CAN
-  GCAM v5.1|Central America and the Caribbean:
+  GCAM 5.1|Central America and the Caribbean:
     title: Central America and the Caribbean
     comment: Region 'Central America and the Caribbean' as defined in GCAM version
-      v5.1
+      5.1
     children:
     - - ABW
       - AIA
@@ -2736,9 +2736,9 @@ categories:
       - SLV
       - TTO
       - VCT
-  GCAM v5.1|Central Asia:
+  GCAM 5.1|Central Asia:
     title: Central Asia
-    comment: Region 'Central Asia' as defined in GCAM version v5.1
+    comment: Region 'Central Asia' as defined in GCAM version 5.1
     children:
     - - ARM
       - AZE
@@ -2749,19 +2749,19 @@ categories:
       - TJK
       - TKM
       - UZB
-  GCAM v5.1|China:
+  GCAM 5.1|China:
     title: China
-    comment: Region 'China' as defined in GCAM version v5.1
+    comment: Region 'China' as defined in GCAM version 5.1
     children:
     - - CHN
-  GCAM v5.1|Colombia:
+  GCAM 5.1|Colombia:
     title: Colombia
-    comment: Region 'Colombia' as defined in GCAM version v5.1
+    comment: Region 'Colombia' as defined in GCAM version 5.1
     children:
     - - COL
-  GCAM v5.1|EU-12:
+  GCAM 5.1|EU-12:
     title: EU-12
-    comment: Region 'EU-12' as defined in GCAM version v5.1
+    comment: Region 'EU-12' as defined in GCAM version 5.1
     children:
     - - BGR
       - CYP
@@ -2775,9 +2775,9 @@ categories:
       - ROU
       - SVK
       - SVN
-  GCAM v5.1|EU-15:
+  GCAM 5.1|EU-15:
     title: EU-15
-    comment: Region 'EU-15' as defined in GCAM version v5.1
+    comment: Region 'EU-15' as defined in GCAM version 5.1
     children:
     - - AND
       - AUT
@@ -2797,23 +2797,23 @@ categories:
       - NLD
       - PRT
       - SWE
-  GCAM v5.1|Europe_Eastern:
+  GCAM 5.1|Europe_Eastern:
     title: Europe_Eastern
-    comment: Region 'Europe_Eastern' as defined in GCAM version v5.1
+    comment: Region 'Europe_Eastern' as defined in GCAM version 5.1
     children:
     - - BLR
       - MDA
       - UKR
-  GCAM v5.1|European Free Trade Association:
+  GCAM 5.1|European Free Trade Association:
     title: European Free Trade Association
-    comment: Region 'European Free Trade Association' as defined in GCAM version v5.1
+    comment: Region 'European Free Trade Association' as defined in GCAM version 5.1
     children:
     - - CHE
       - ISL
       - NOR
-  GCAM v5.1|Europe_Non_EU:
+  GCAM 5.1|Europe_Non_EU:
     title: Europe_Non_EU
-    comment: Region 'Europe_Non_EU' as defined in GCAM version v5.1
+    comment: Region 'Europe_Non_EU' as defined in GCAM version 5.1
     children:
     - - ALB
       - BIH
@@ -2822,29 +2822,29 @@ categories:
       - MNE
       - SRB
       - TUR
-  GCAM v5.1|India:
+  GCAM 5.1|India:
     title: India
-    comment: Region 'India' as defined in GCAM version v5.1
+    comment: Region 'India' as defined in GCAM version 5.1
     children:
     - - IND
-  GCAM v5.1|Indonesia:
+  GCAM 5.1|Indonesia:
     title: Indonesia
-    comment: Region 'Indonesia' as defined in GCAM version v5.1
+    comment: Region 'Indonesia' as defined in GCAM version 5.1
     children:
     - - IDN
-  GCAM v5.1|Japan:
+  GCAM 5.1|Japan:
     title: Japan
-    comment: Region 'Japan' as defined in GCAM version v5.1
+    comment: Region 'Japan' as defined in GCAM version 5.1
     children:
     - - JPN
-  GCAM v5.1|Mexico:
+  GCAM 5.1|Mexico:
     title: Mexico
-    comment: Region 'Mexico' as defined in GCAM version v5.1
+    comment: Region 'Mexico' as defined in GCAM version 5.1
     children:
     - - MEX
-  GCAM v5.1|Middle East:
+  GCAM 5.1|Middle East:
     title: Middle East
-    comment: Region 'Middle East' as defined in GCAM version v5.1
+    comment: Region 'Middle East' as defined in GCAM version 5.1
     children:
     - - ARE
       - BHR
@@ -2860,32 +2860,32 @@ categories:
       - SAU
       - SYR
       - YEM
-  GCAM v5.1|Pakistan:
+  GCAM 5.1|Pakistan:
     title: Pakistan
-    comment: Region 'Pakistan' as defined in GCAM version v5.1
+    comment: Region 'Pakistan' as defined in GCAM version 5.1
     children:
     - - PAK
-  GCAM v5.1|Russia:
+  GCAM 5.1|Russia:
     title: Russia
-    comment: Region 'Russia' as defined in GCAM version v5.1
+    comment: Region 'Russia' as defined in GCAM version 5.1
     children:
     - - RUS
-  GCAM v5.1|South Africa:
+  GCAM 5.1|South Africa:
     title: South Africa
-    comment: Region 'South Africa' as defined in GCAM version v5.1
+    comment: Region 'South Africa' as defined in GCAM version 5.1
     children:
     - - ZAF
-  GCAM v5.1|South America_Northern:
+  GCAM 5.1|South America_Northern:
     title: South America_Northern
-    comment: Region 'South America_Northern' as defined in GCAM version v5.1
+    comment: Region 'South America_Northern' as defined in GCAM version 5.1
     children:
     - - GUF
       - GUY
       - SUR
       - VEN
-  GCAM v5.1|South America_Southern:
+  GCAM 5.1|South America_Southern:
     title: South America_Southern
-    comment: Region 'South America_Southern' as defined in GCAM version v5.1
+    comment: Region 'South America_Southern' as defined in GCAM version 5.1
     children:
     - - BOL
       - CHL
@@ -2893,9 +2893,9 @@ categories:
       - PER
       - PRY
       - URY
-  GCAM v5.1|South Asia:
+  GCAM 5.1|South Asia:
     title: South Asia
-    comment: Region 'South Asia' as defined in GCAM version v5.1
+    comment: Region 'South Asia' as defined in GCAM version 5.1
     children:
     - - AFG
       - BGD
@@ -2903,9 +2903,9 @@ categories:
       - LKA
       - MDV
       - NPL
-  GCAM v5.1|Southeast Asia:
+  GCAM 5.1|Southeast Asia:
     title: Southeast Asia
-    comment: Region 'Southeast Asia' as defined in GCAM version v5.1
+    comment: Region 'Southeast Asia' as defined in GCAM version 5.1
     children:
     - - ASM
       - BRN
@@ -2944,24 +2944,24 @@ categories:
       - VNM
       - VUT
       - WSM
-  GCAM v5.1|South Korea:
+  GCAM 5.1|South Korea:
     title: South Korea
-    comment: Region 'South Korea' as defined in GCAM version v5.1
+    comment: Region 'South Korea' as defined in GCAM version 5.1
     children:
     - - KOR
-  GCAM v5.1|Taiwan:
+  GCAM 5.1|Taiwan:
     title: Taiwan
-    comment: Region 'Taiwan' as defined in GCAM version v5.1
+    comment: Region 'Taiwan' as defined in GCAM version 5.1
     children:
     - - TWN
-  GCAM v5.1|USA:
+  GCAM 5.1|USA:
     title: USA
-    comment: Region 'USA' as defined in GCAM version v5.1
+    comment: Region 'USA' as defined in GCAM version 5.1
     children:
     - - USA
-  GCAM v5.2|Africa_Eastern:
+  GCAM 5.2|Africa_Eastern:
     title: Africa_Eastern
-    comment: Region 'Africa_Eastern' as defined in GCAM version v5.2
+    comment: Region 'Africa_Eastern' as defined in GCAM version 5.2
     children:
     - - BDI
       - COM
@@ -2976,9 +2976,9 @@ categories:
       - SDN
       - SOM
       - UGA
-  GCAM v5.2|Africa_Northern:
+  GCAM 5.2|Africa_Northern:
     title: Africa_Northern
-    comment: Region 'Africa_Northern' as defined in GCAM version v5.2
+    comment: Region 'Africa_Northern' as defined in GCAM version 5.2
     children:
     - - DZA
       - EGY
@@ -2986,9 +2986,9 @@ categories:
       - LBY
       - MAR
       - TUN
-  GCAM v5.2|Africa_Southern:
+  GCAM 5.2|Africa_Southern:
     title: Africa_Southern
-    comment: Region 'Africa_Southern' as defined in GCAM version v5.2
+    comment: Region 'Africa_Southern' as defined in GCAM version 5.2
     children:
     - - AGO
       - BWA
@@ -3000,9 +3000,9 @@ categories:
       - TZA
       - ZMB
       - ZWE
-  GCAM v5.2|Africa_Western:
+  GCAM 5.2|Africa_Western:
     title: Africa_Western
-    comment: Region 'Africa_Western' as defined in GCAM version v5.2
+    comment: Region 'Africa_Western' as defined in GCAM version 5.2
     children:
     - - BEN
       - BFA
@@ -3028,31 +3028,31 @@ categories:
       - STP
       - TCD
       - TGO
-  GCAM v5.2|Argentina:
+  GCAM 5.2|Argentina:
     title: Argentina
-    comment: Region 'Argentina' as defined in GCAM version v5.2
+    comment: Region 'Argentina' as defined in GCAM version 5.2
     children:
     - - ARG
-  GCAM v5.2|Australia_NZ:
+  GCAM 5.2|Australia_NZ:
     title: Australia_NZ
-    comment: Region 'Australia_NZ' as defined in GCAM version v5.2
+    comment: Region 'Australia_NZ' as defined in GCAM version 5.2
     children:
     - - AUS
       - NZL
-  GCAM v5.2|Brazil:
+  GCAM 5.2|Brazil:
     title: Brazil
-    comment: Region 'Brazil' as defined in GCAM version v5.2
+    comment: Region 'Brazil' as defined in GCAM version 5.2
     children:
     - - BRA
-  GCAM v5.2|Canada:
+  GCAM 5.2|Canada:
     title: Canada
-    comment: Region 'Canada' as defined in GCAM version v5.2
+    comment: Region 'Canada' as defined in GCAM version 5.2
     children:
     - - CAN
-  GCAM v5.2|Central America and the Caribbean:
+  GCAM 5.2|Central America and the Caribbean:
     title: Central America and the Caribbean
     comment: Region 'Central America and the Caribbean' as defined in GCAM version
-      v5.2
+      5.2
     children:
     - - ABW
       - AIA
@@ -3081,9 +3081,9 @@ categories:
       - SLV
       - TTO
       - VCT
-  GCAM v5.2|Central Asia:
+  GCAM 5.2|Central Asia:
     title: Central Asia
-    comment: Region 'Central Asia' as defined in GCAM version v5.2
+    comment: Region 'Central Asia' as defined in GCAM version 5.2
     children:
     - - ARM
       - AZE
@@ -3094,19 +3094,19 @@ categories:
       - TJK
       - TKM
       - UZB
-  GCAM v5.2|China:
+  GCAM 5.2|China:
     title: China
-    comment: Region 'China' as defined in GCAM version v5.2
+    comment: Region 'China' as defined in GCAM version 5.2
     children:
     - - CHN
-  GCAM v5.2|Colombia:
+  GCAM 5.2|Colombia:
     title: Colombia
-    comment: Region 'Colombia' as defined in GCAM version v5.2
+    comment: Region 'Colombia' as defined in GCAM version 5.2
     children:
     - - COL
-  GCAM v5.2|EU-12:
+  GCAM 5.2|EU-12:
     title: EU-12
-    comment: Region 'EU-12' as defined in GCAM version v5.2
+    comment: Region 'EU-12' as defined in GCAM version 5.2
     children:
     - - BGR
       - CYP
@@ -3120,9 +3120,9 @@ categories:
       - ROU
       - SVK
       - SVN
-  GCAM v5.2|EU-15:
+  GCAM 5.2|EU-15:
     title: EU-15
-    comment: Region 'EU-15' as defined in GCAM version v5.2
+    comment: Region 'EU-15' as defined in GCAM version 5.2
     children:
     - - AND
       - AUT
@@ -3142,23 +3142,23 @@ categories:
       - NLD
       - PRT
       - SWE
-  GCAM v5.2|Europe_Eastern:
+  GCAM 5.2|Europe_Eastern:
     title: Europe_Eastern
-    comment: Region 'Europe_Eastern' as defined in GCAM version v5.2
+    comment: Region 'Europe_Eastern' as defined in GCAM version 5.2
     children:
     - - BLR
       - MDA
       - UKR
-  GCAM v5.2|European Free Trade Association:
+  GCAM 5.2|European Free Trade Association:
     title: European Free Trade Association
-    comment: Region 'European Free Trade Association' as defined in GCAM version v5.2
+    comment: Region 'European Free Trade Association' as defined in GCAM version 5.2
     children:
     - - CHE
       - ISL
       - NOR
-  GCAM v5.2|Europe_Non_EU:
+  GCAM 5.2|Europe_Non_EU:
     title: Europe_Non_EU
-    comment: Region 'Europe_Non_EU' as defined in GCAM version v5.2
+    comment: Region 'Europe_Non_EU' as defined in GCAM version 5.2
     children:
     - - ALB
       - BIH
@@ -3167,29 +3167,29 @@ categories:
       - MNE
       - SRB
       - TUR
-  GCAM v5.2|India:
+  GCAM 5.2|India:
     title: India
-    comment: Region 'India' as defined in GCAM version v5.2
+    comment: Region 'India' as defined in GCAM version 5.2
     children:
     - - IND
-  GCAM v5.2|Indonesia:
+  GCAM 5.2|Indonesia:
     title: Indonesia
-    comment: Region 'Indonesia' as defined in GCAM version v5.2
+    comment: Region 'Indonesia' as defined in GCAM version 5.2
     children:
     - - IDN
-  GCAM v5.2|Japan:
+  GCAM 5.2|Japan:
     title: Japan
-    comment: Region 'Japan' as defined in GCAM version v5.2
+    comment: Region 'Japan' as defined in GCAM version 5.2
     children:
     - - JPN
-  GCAM v5.2|Mexico:
+  GCAM 5.2|Mexico:
     title: Mexico
-    comment: Region 'Mexico' as defined in GCAM version v5.2
+    comment: Region 'Mexico' as defined in GCAM version 5.2
     children:
     - - MEX
-  GCAM v5.2|Middle East:
+  GCAM 5.2|Middle East:
     title: Middle East
-    comment: Region 'Middle East' as defined in GCAM version v5.2
+    comment: Region 'Middle East' as defined in GCAM version 5.2
     children:
     - - ARE
       - BHR
@@ -3205,32 +3205,32 @@ categories:
       - SAU
       - SYR
       - YEM
-  GCAM v5.2|Pakistan:
+  GCAM 5.2|Pakistan:
     title: Pakistan
-    comment: Region 'Pakistan' as defined in GCAM version v5.2
+    comment: Region 'Pakistan' as defined in GCAM version 5.2
     children:
     - - PAK
-  GCAM v5.2|Russia:
+  GCAM 5.2|Russia:
     title: Russia
-    comment: Region 'Russia' as defined in GCAM version v5.2
+    comment: Region 'Russia' as defined in GCAM version 5.2
     children:
     - - RUS
-  GCAM v5.2|South Africa:
+  GCAM 5.2|South Africa:
     title: South Africa
-    comment: Region 'South Africa' as defined in GCAM version v5.2
+    comment: Region 'South Africa' as defined in GCAM version 5.2
     children:
     - - ZAF
-  GCAM v5.2|South America_Northern:
+  GCAM 5.2|South America_Northern:
     title: South America_Northern
-    comment: Region 'South America_Northern' as defined in GCAM version v5.2
+    comment: Region 'South America_Northern' as defined in GCAM version 5.2
     children:
     - - GUF
       - GUY
       - SUR
       - VEN
-  GCAM v5.2|South America_Southern:
+  GCAM 5.2|South America_Southern:
     title: South America_Southern
-    comment: Region 'South America_Southern' as defined in GCAM version v5.2
+    comment: Region 'South America_Southern' as defined in GCAM version 5.2
     children:
     - - BOL
       - CHL
@@ -3238,9 +3238,9 @@ categories:
       - PER
       - PRY
       - URY
-  GCAM v5.2|South Asia:
+  GCAM 5.2|South Asia:
     title: South Asia
-    comment: Region 'South Asia' as defined in GCAM version v5.2
+    comment: Region 'South Asia' as defined in GCAM version 5.2
     children:
     - - AFG
       - BGD
@@ -3248,9 +3248,9 @@ categories:
       - LKA
       - MDV
       - NPL
-  GCAM v5.2|Southeast Asia:
+  GCAM 5.2|Southeast Asia:
     title: Southeast Asia
-    comment: Region 'Southeast Asia' as defined in GCAM version v5.2
+    comment: Region 'Southeast Asia' as defined in GCAM version 5.2
     children:
     - - ASM
       - BRN
@@ -3289,24 +3289,24 @@ categories:
       - VNM
       - VUT
       - WSM
-  GCAM v5.2|South Korea:
+  GCAM 5.2|South Korea:
     title: South Korea
-    comment: Region 'South Korea' as defined in GCAM version v5.2
+    comment: Region 'South Korea' as defined in GCAM version 5.2
     children:
     - - KOR
-  GCAM v5.2|Taiwan:
+  GCAM 5.2|Taiwan:
     title: Taiwan
-    comment: Region 'Taiwan' as defined in GCAM version v5.2
+    comment: Region 'Taiwan' as defined in GCAM version 5.2
     children:
     - - TWN
-  GCAM v5.2|USA:
+  GCAM 5.2|USA:
     title: USA
-    comment: Region 'USA' as defined in GCAM version v5.2
+    comment: Region 'USA' as defined in GCAM version 5.2
     children:
     - - USA
-  GCAM v5.3|Africa_Eastern:
+  GCAM 5.3|Africa_Eastern:
     title: Africa_Eastern
-    comment: Region 'Africa_Eastern' as defined in GCAM version v5.3
+    comment: Region 'Africa_Eastern' as defined in GCAM version 5.3
     children:
     - - BDI
       - COM
@@ -3321,9 +3321,9 @@ categories:
       - SDN
       - SOM
       - UGA
-  GCAM v5.3|Africa_Northern:
+  GCAM 5.3|Africa_Northern:
     title: Africa_Northern
-    comment: Region 'Africa_Northern' as defined in GCAM version v5.3
+    comment: Region 'Africa_Northern' as defined in GCAM version 5.3
     children:
     - - DZA
       - EGY
@@ -3331,9 +3331,9 @@ categories:
       - LBY
       - MAR
       - TUN
-  GCAM v5.3|Africa_Southern:
+  GCAM 5.3|Africa_Southern:
     title: Africa_Southern
-    comment: Region 'Africa_Southern' as defined in GCAM version v5.3
+    comment: Region 'Africa_Southern' as defined in GCAM version 5.3
     children:
     - - AGO
       - BWA
@@ -3345,9 +3345,9 @@ categories:
       - TZA
       - ZMB
       - ZWE
-  GCAM v5.3|Africa_Western:
+  GCAM 5.3|Africa_Western:
     title: Africa_Western
-    comment: Region 'Africa_Western' as defined in GCAM version v5.3
+    comment: Region 'Africa_Western' as defined in GCAM version 5.3
     children:
     - - BEN
       - BFA
@@ -3373,31 +3373,31 @@ categories:
       - STP
       - TCD
       - TGO
-  GCAM v5.3|Argentina:
+  GCAM 5.3|Argentina:
     title: Argentina
-    comment: Region 'Argentina' as defined in GCAM version v5.3
+    comment: Region 'Argentina' as defined in GCAM version 5.3
     children:
     - - ARG
-  GCAM v5.3|Australia_NZ:
+  GCAM 5.3|Australia_NZ:
     title: Australia_NZ
-    comment: Region 'Australia_NZ' as defined in GCAM version v5.3
+    comment: Region 'Australia_NZ' as defined in GCAM version 5.3
     children:
     - - AUS
       - NZL
-  GCAM v5.3|Brazil:
+  GCAM 5.3|Brazil:
     title: Brazil
-    comment: Region 'Brazil' as defined in GCAM version v5.3
+    comment: Region 'Brazil' as defined in GCAM version 5.3
     children:
     - - BRA
-  GCAM v5.3|Canada:
+  GCAM 5.3|Canada:
     title: Canada
-    comment: Region 'Canada' as defined in GCAM version v5.3
+    comment: Region 'Canada' as defined in GCAM version 5.3
     children:
     - - CAN
-  GCAM v5.3|Central America and the Caribbean:
+  GCAM 5.3|Central America and the Caribbean:
     title: Central America and the Caribbean
     comment: Region 'Central America and the Caribbean' as defined in GCAM version
-      v5.3
+      5.3
     children:
     - - ABW
       - AIA
@@ -3426,9 +3426,9 @@ categories:
       - SLV
       - TTO
       - VCT
-  GCAM v5.3|Central Asia:
+  GCAM 5.3|Central Asia:
     title: Central Asia
-    comment: Region 'Central Asia' as defined in GCAM version v5.3
+    comment: Region 'Central Asia' as defined in GCAM version 5.3
     children:
     - - ARM
       - AZE
@@ -3439,19 +3439,19 @@ categories:
       - TJK
       - TKM
       - UZB
-  GCAM v5.3|China:
+  GCAM 5.3|China:
     title: China
-    comment: Region 'China' as defined in GCAM version v5.3
+    comment: Region 'China' as defined in GCAM version 5.3
     children:
     - - CHN
-  GCAM v5.3|Colombia:
+  GCAM 5.3|Colombia:
     title: Colombia
-    comment: Region 'Colombia' as defined in GCAM version v5.3
+    comment: Region 'Colombia' as defined in GCAM version 5.3
     children:
     - - COL
-  GCAM v5.3|EU-12:
+  GCAM 5.3|EU-12:
     title: EU-12
-    comment: Region 'EU-12' as defined in GCAM version v5.3
+    comment: Region 'EU-12' as defined in GCAM version 5.3
     children:
     - - BGR
       - CYP
@@ -3465,9 +3465,9 @@ categories:
       - ROU
       - SVK
       - SVN
-  GCAM v5.3|EU-15:
+  GCAM 5.3|EU-15:
     title: EU-15
-    comment: Region 'EU-15' as defined in GCAM version v5.3
+    comment: Region 'EU-15' as defined in GCAM version 5.3
     children:
     - - AND
       - AUT
@@ -3487,23 +3487,23 @@ categories:
       - NLD
       - PRT
       - SWE
-  GCAM v5.3|Europe_Eastern:
+  GCAM 5.3|Europe_Eastern:
     title: Europe_Eastern
-    comment: Region 'Europe_Eastern' as defined in GCAM version v5.3
+    comment: Region 'Europe_Eastern' as defined in GCAM version 5.3
     children:
     - - BLR
       - MDA
       - UKR
-  GCAM v5.3|European Free Trade Association:
+  GCAM 5.3|European Free Trade Association:
     title: European Free Trade Association
-    comment: Region 'European Free Trade Association' as defined in GCAM version v5.3
+    comment: Region 'European Free Trade Association' as defined in GCAM version 5.3
     children:
     - - CHE
       - ISL
       - NOR
-  GCAM v5.3|Europe_Non_EU:
+  GCAM 5.3|Europe_Non_EU:
     title: Europe_Non_EU
-    comment: Region 'Europe_Non_EU' as defined in GCAM version v5.3
+    comment: Region 'Europe_Non_EU' as defined in GCAM version 5.3
     children:
     - - ALB
       - BIH
@@ -3512,29 +3512,29 @@ categories:
       - MNE
       - SRB
       - TUR
-  GCAM v5.3|India:
+  GCAM 5.3|India:
     title: India
-    comment: Region 'India' as defined in GCAM version v5.3
+    comment: Region 'India' as defined in GCAM version 5.3
     children:
     - - IND
-  GCAM v5.3|Indonesia:
+  GCAM 5.3|Indonesia:
     title: Indonesia
-    comment: Region 'Indonesia' as defined in GCAM version v5.3
+    comment: Region 'Indonesia' as defined in GCAM version 5.3
     children:
     - - IDN
-  GCAM v5.3|Japan:
+  GCAM 5.3|Japan:
     title: Japan
-    comment: Region 'Japan' as defined in GCAM version v5.3
+    comment: Region 'Japan' as defined in GCAM version 5.3
     children:
     - - JPN
-  GCAM v5.3|Mexico:
+  GCAM 5.3|Mexico:
     title: Mexico
-    comment: Region 'Mexico' as defined in GCAM version v5.3
+    comment: Region 'Mexico' as defined in GCAM version 5.3
     children:
     - - MEX
-  GCAM v5.3|Middle East:
+  GCAM 5.3|Middle East:
     title: Middle East
-    comment: Region 'Middle East' as defined in GCAM version v5.3
+    comment: Region 'Middle East' as defined in GCAM version 5.3
     children:
     - - ARE
       - BHR
@@ -3550,32 +3550,32 @@ categories:
       - SAU
       - SYR
       - YEM
-  GCAM v5.3|Pakistan:
+  GCAM 5.3|Pakistan:
     title: Pakistan
-    comment: Region 'Pakistan' as defined in GCAM version v5.3
+    comment: Region 'Pakistan' as defined in GCAM version 5.3
     children:
     - - PAK
-  GCAM v5.3|Russia:
+  GCAM 5.3|Russia:
     title: Russia
-    comment: Region 'Russia' as defined in GCAM version v5.3
+    comment: Region 'Russia' as defined in GCAM version 5.3
     children:
     - - RUS
-  GCAM v5.3|South Africa:
+  GCAM 5.3|South Africa:
     title: South Africa
-    comment: Region 'South Africa' as defined in GCAM version v5.3
+    comment: Region 'South Africa' as defined in GCAM version 5.3
     children:
     - - ZAF
-  GCAM v5.3|South America_Northern:
+  GCAM 5.3|South America_Northern:
     title: South America_Northern
-    comment: Region 'South America_Northern' as defined in GCAM version v5.3
+    comment: Region 'South America_Northern' as defined in GCAM version 5.3
     children:
     - - GUF
       - GUY
       - SUR
       - VEN
-  GCAM v5.3|South America_Southern:
+  GCAM 5.3|South America_Southern:
     title: South America_Southern
-    comment: Region 'South America_Southern' as defined in GCAM version v5.3
+    comment: Region 'South America_Southern' as defined in GCAM version 5.3
     children:
     - - BOL
       - CHL
@@ -3583,9 +3583,9 @@ categories:
       - PER
       - PRY
       - URY
-  GCAM v5.3|South Asia:
+  GCAM 5.3|South Asia:
     title: South Asia
-    comment: Region 'South Asia' as defined in GCAM version v5.3
+    comment: Region 'South Asia' as defined in GCAM version 5.3
     children:
     - - AFG
       - BGD
@@ -3593,9 +3593,9 @@ categories:
       - LKA
       - MDV
       - NPL
-  GCAM v5.3|Southeast Asia:
+  GCAM 5.3|Southeast Asia:
     title: Southeast Asia
-    comment: Region 'Southeast Asia' as defined in GCAM version v5.3
+    comment: Region 'Southeast Asia' as defined in GCAM version 5.3
     children:
     - - ASM
       - BRN
@@ -3634,24 +3634,24 @@ categories:
       - VNM
       - VUT
       - WSM
-  GCAM v5.3|South Korea:
+  GCAM 5.3|South Korea:
     title: South Korea
-    comment: Region 'South Korea' as defined in GCAM version v5.3
+    comment: Region 'South Korea' as defined in GCAM version 5.3
     children:
     - - KOR
-  GCAM v5.3|Taiwan:
+  GCAM 5.3|Taiwan:
     title: Taiwan
-    comment: Region 'Taiwan' as defined in GCAM version v5.3
+    comment: Region 'Taiwan' as defined in GCAM version 5.3
     children:
     - - TWN
-  GCAM v5.3|USA:
+  GCAM 5.3|USA:
     title: USA
-    comment: Region 'USA' as defined in GCAM version v5.3
+    comment: Region 'USA' as defined in GCAM version 5.3
     children:
     - - USA
-  GCAM v5.4|Africa_Eastern:
+  GCAM 5.4|Africa_Eastern:
     title: Africa_Eastern
-    comment: Region 'Africa_Eastern' as defined in GCAM version v5.4
+    comment: Region 'Africa_Eastern' as defined in GCAM version 5.4
     children:
     - - BDI
       - COM
@@ -3666,9 +3666,9 @@ categories:
       - SDN
       - SOM
       - UGA
-  GCAM v5.4|Africa_Northern:
+  GCAM 5.4|Africa_Northern:
     title: Africa_Northern
-    comment: Region 'Africa_Northern' as defined in GCAM version v5.4
+    comment: Region 'Africa_Northern' as defined in GCAM version 5.4
     children:
     - - DZA
       - EGY
@@ -3676,9 +3676,9 @@ categories:
       - LBY
       - MAR
       - TUN
-  GCAM v5.4|Africa_Southern:
+  GCAM 5.4|Africa_Southern:
     title: Africa_Southern
-    comment: Region 'Africa_Southern' as defined in GCAM version v5.4
+    comment: Region 'Africa_Southern' as defined in GCAM version 5.4
     children:
     - - AGO
       - BWA
@@ -3690,9 +3690,9 @@ categories:
       - TZA
       - ZMB
       - ZWE
-  GCAM v5.4|Africa_Western:
+  GCAM 5.4|Africa_Western:
     title: Africa_Western
-    comment: Region 'Africa_Western' as defined in GCAM version v5.4
+    comment: Region 'Africa_Western' as defined in GCAM version 5.4
     children:
     - - BEN
       - BFA
@@ -3718,31 +3718,31 @@ categories:
       - STP
       - TCD
       - TGO
-  GCAM v5.4|Argentina:
+  GCAM 5.4|Argentina:
     title: Argentina
-    comment: Region 'Argentina' as defined in GCAM version v5.4
+    comment: Region 'Argentina' as defined in GCAM version 5.4
     children:
     - - ARG
-  GCAM v5.4|Australia_NZ:
+  GCAM 5.4|Australia_NZ:
     title: Australia_NZ
-    comment: Region 'Australia_NZ' as defined in GCAM version v5.4
+    comment: Region 'Australia_NZ' as defined in GCAM version 5.4
     children:
     - - AUS
       - NZL
-  GCAM v5.4|Brazil:
+  GCAM 5.4|Brazil:
     title: Brazil
-    comment: Region 'Brazil' as defined in GCAM version v5.4
+    comment: Region 'Brazil' as defined in GCAM version 5.4
     children:
     - - BRA
-  GCAM v5.4|Canada:
+  GCAM 5.4|Canada:
     title: Canada
-    comment: Region 'Canada' as defined in GCAM version v5.4
+    comment: Region 'Canada' as defined in GCAM version 5.4
     children:
     - - CAN
-  GCAM v5.4|Central America and the Caribbean:
+  GCAM 5.4|Central America and the Caribbean:
     title: Central America and the Caribbean
     comment: Region 'Central America and the Caribbean' as defined in GCAM version
-      v5.4
+      5.4
     children:
     - - ABW
       - AIA
@@ -3771,9 +3771,9 @@ categories:
       - SLV
       - TTO
       - VCT
-  GCAM v5.4|Central Asia:
+  GCAM 5.4|Central Asia:
     title: Central Asia
-    comment: Region 'Central Asia' as defined in GCAM version v5.4
+    comment: Region 'Central Asia' as defined in GCAM version 5.4
     children:
     - - ARM
       - AZE
@@ -3784,19 +3784,19 @@ categories:
       - TJK
       - TKM
       - UZB
-  GCAM v5.4|China:
+  GCAM 5.4|China:
     title: China
-    comment: Region 'China' as defined in GCAM version v5.4
+    comment: Region 'China' as defined in GCAM version 5.4
     children:
     - - CHN
-  GCAM v5.4|Colombia:
+  GCAM 5.4|Colombia:
     title: Colombia
-    comment: Region 'Colombia' as defined in GCAM version v5.4
+    comment: Region 'Colombia' as defined in GCAM version 5.4
     children:
     - - COL
-  GCAM v5.4|EU-12:
+  GCAM 5.4|EU-12:
     title: EU-12
-    comment: Region 'EU-12' as defined in GCAM version v5.4
+    comment: Region 'EU-12' as defined in GCAM version 5.4
     children:
     - - BGR
       - CYP
@@ -3810,9 +3810,9 @@ categories:
       - ROU
       - SVK
       - SVN
-  GCAM v5.4|EU-15:
+  GCAM 5.4|EU-15:
     title: EU-15
-    comment: Region 'EU-15' as defined in GCAM version v5.4
+    comment: Region 'EU-15' as defined in GCAM version 5.4
     children:
     - - AND
       - AUT
@@ -3832,23 +3832,23 @@ categories:
       - NLD
       - PRT
       - SWE
-  GCAM v5.4|Europe_Eastern:
+  GCAM 5.4|Europe_Eastern:
     title: Europe_Eastern
-    comment: Region 'Europe_Eastern' as defined in GCAM version v5.4
+    comment: Region 'Europe_Eastern' as defined in GCAM version 5.4
     children:
     - - BLR
       - MDA
       - UKR
-  GCAM v5.4|European Free Trade Association:
+  GCAM 5.4|European Free Trade Association:
     title: European Free Trade Association
-    comment: Region 'European Free Trade Association' as defined in GCAM version v5.4
+    comment: Region 'European Free Trade Association' as defined in GCAM version 5.4
     children:
     - - CHE
       - ISL
       - NOR
-  GCAM v5.4|Europe_Non_EU:
+  GCAM 5.4|Europe_Non_EU:
     title: Europe_Non_EU
-    comment: Region 'Europe_Non_EU' as defined in GCAM version v5.4
+    comment: Region 'Europe_Non_EU' as defined in GCAM version 5.4
     children:
     - - ALB
       - BIH
@@ -3857,29 +3857,29 @@ categories:
       - MNE
       - SRB
       - TUR
-  GCAM v5.4|India:
+  GCAM 5.4|India:
     title: India
-    comment: Region 'India' as defined in GCAM version v5.4
+    comment: Region 'India' as defined in GCAM version 5.4
     children:
     - - IND
-  GCAM v5.4|Indonesia:
+  GCAM 5.4|Indonesia:
     title: Indonesia
-    comment: Region 'Indonesia' as defined in GCAM version v5.4
+    comment: Region 'Indonesia' as defined in GCAM version 5.4
     children:
     - - IDN
-  GCAM v5.4|Japan:
+  GCAM 5.4|Japan:
     title: Japan
-    comment: Region 'Japan' as defined in GCAM version v5.4
+    comment: Region 'Japan' as defined in GCAM version 5.4
     children:
     - - JPN
-  GCAM v5.4|Mexico:
+  GCAM 5.4|Mexico:
     title: Mexico
-    comment: Region 'Mexico' as defined in GCAM version v5.4
+    comment: Region 'Mexico' as defined in GCAM version 5.4
     children:
     - - MEX
-  GCAM v5.4|Middle East:
+  GCAM 5.4|Middle East:
     title: Middle East
-    comment: Region 'Middle East' as defined in GCAM version v5.4
+    comment: Region 'Middle East' as defined in GCAM version 5.4
     children:
     - - ARE
       - BHR
@@ -3895,32 +3895,32 @@ categories:
       - SAU
       - SYR
       - YEM
-  GCAM v5.4|Pakistan:
+  GCAM 5.4|Pakistan:
     title: Pakistan
-    comment: Region 'Pakistan' as defined in GCAM version v5.4
+    comment: Region 'Pakistan' as defined in GCAM version 5.4
     children:
     - - PAK
-  GCAM v5.4|Russia:
+  GCAM 5.4|Russia:
     title: Russia
-    comment: Region 'Russia' as defined in GCAM version v5.4
+    comment: Region 'Russia' as defined in GCAM version 5.4
     children:
     - - RUS
-  GCAM v5.4|South Africa:
+  GCAM 5.4|South Africa:
     title: South Africa
-    comment: Region 'South Africa' as defined in GCAM version v5.4
+    comment: Region 'South Africa' as defined in GCAM version 5.4
     children:
     - - ZAF
-  GCAM v5.4|South America_Northern:
+  GCAM 5.4|South America_Northern:
     title: South America_Northern
-    comment: Region 'South America_Northern' as defined in GCAM version v5.4
+    comment: Region 'South America_Northern' as defined in GCAM version 5.4
     children:
     - - GUF
       - GUY
       - SUR
       - VEN
-  GCAM v5.4|South America_Southern:
+  GCAM 5.4|South America_Southern:
     title: South America_Southern
-    comment: Region 'South America_Southern' as defined in GCAM version v5.4
+    comment: Region 'South America_Southern' as defined in GCAM version 5.4
     children:
     - - BOL
       - CHL
@@ -3928,9 +3928,9 @@ categories:
       - PER
       - PRY
       - URY
-  GCAM v5.4|South Asia:
+  GCAM 5.4|South Asia:
     title: South Asia
-    comment: Region 'South Asia' as defined in GCAM version v5.4
+    comment: Region 'South Asia' as defined in GCAM version 5.4
     children:
     - - AFG
       - BGD
@@ -3938,9 +3938,9 @@ categories:
       - LKA
       - MDV
       - NPL
-  GCAM v5.4|Southeast Asia:
+  GCAM 5.4|Southeast Asia:
     title: Southeast Asia
-    comment: Region 'Southeast Asia' as defined in GCAM version v5.4
+    comment: Region 'Southeast Asia' as defined in GCAM version 5.4
     children:
     - - ASM
       - BRN
@@ -3979,24 +3979,24 @@ categories:
       - VNM
       - VUT
       - WSM
-  GCAM v5.4|South Korea:
+  GCAM 5.4|South Korea:
     title: South Korea
-    comment: Region 'South Korea' as defined in GCAM version v5.4
+    comment: Region 'South Korea' as defined in GCAM version 5.4
     children:
     - - KOR
-  GCAM v5.4|Taiwan:
+  GCAM 5.4|Taiwan:
     title: Taiwan
-    comment: Region 'Taiwan' as defined in GCAM version v5.4
+    comment: Region 'Taiwan' as defined in GCAM version 5.4
     children:
     - - TWN
-  GCAM v5.4|USA:
+  GCAM 5.4|USA:
     title: USA
-    comment: Region 'USA' as defined in GCAM version v5.4
+    comment: Region 'USA' as defined in GCAM version 5.4
     children:
     - - USA
-  GCAM v6.0|Africa_Eastern:
+  GCAM 6.0|Africa_Eastern:
     title: Africa_Eastern
-    comment: Region 'Africa_Eastern' as defined in GCAM version v6.0
+    comment: Region 'Africa_Eastern' as defined in GCAM version 6.0
     children:
     - - BDI
       - COM
@@ -4011,9 +4011,9 @@ categories:
       - SDN
       - SOM
       - UGA
-  GCAM v6.0|Africa_Northern:
+  GCAM 6.0|Africa_Northern:
     title: Africa_Northern
-    comment: Region 'Africa_Northern' as defined in GCAM version v6.0
+    comment: Region 'Africa_Northern' as defined in GCAM version 6.0
     children:
     - - DZA
       - EGY
@@ -4021,9 +4021,9 @@ categories:
       - LBY
       - MAR
       - TUN
-  GCAM v6.0|Africa_Southern:
+  GCAM 6.0|Africa_Southern:
     title: Africa_Southern
-    comment: Region 'Africa_Southern' as defined in GCAM version v6.0
+    comment: Region 'Africa_Southern' as defined in GCAM version 6.0
     children:
     - - AGO
       - BWA
@@ -4035,9 +4035,9 @@ categories:
       - TZA
       - ZMB
       - ZWE
-  GCAM v6.0|Africa_Western:
+  GCAM 6.0|Africa_Western:
     title: Africa_Western
-    comment: Region 'Africa_Western' as defined in GCAM version v6.0
+    comment: Region 'Africa_Western' as defined in GCAM version 6.0
     children:
     - - BEN
       - BFA
@@ -4063,31 +4063,31 @@ categories:
       - STP
       - TCD
       - TGO
-  GCAM v6.0|Argentina:
+  GCAM 6.0|Argentina:
     title: Argentina
-    comment: Region 'Argentina' as defined in GCAM version v6.0
+    comment: Region 'Argentina' as defined in GCAM version 6.0
     children:
     - - ARG
-  GCAM v6.0|Australia_NZ:
+  GCAM 6.0|Australia_NZ:
     title: Australia_NZ
-    comment: Region 'Australia_NZ' as defined in GCAM version v6.0
+    comment: Region 'Australia_NZ' as defined in GCAM version 6.0
     children:
     - - AUS
       - NZL
-  GCAM v6.0|Brazil:
+  GCAM 6.0|Brazil:
     title: Brazil
-    comment: Region 'Brazil' as defined in GCAM version v6.0
+    comment: Region 'Brazil' as defined in GCAM version 6.0
     children:
     - - BRA
-  GCAM v6.0|Canada:
+  GCAM 6.0|Canada:
     title: Canada
-    comment: Region 'Canada' as defined in GCAM version v6.0
+    comment: Region 'Canada' as defined in GCAM version 6.0
     children:
     - - CAN
-  GCAM v6.0|Central America and the Caribbean:
+  GCAM 6.0|Central America and the Caribbean:
     title: Central America and the Caribbean
     comment: Region 'Central America and the Caribbean' as defined in GCAM version
-      v6.0
+      6.0
     children:
     - - ABW
       - AIA
@@ -4116,9 +4116,9 @@ categories:
       - SLV
       - TTO
       - VCT
-  GCAM v6.0|Central Asia:
+  GCAM 6.0|Central Asia:
     title: Central Asia
-    comment: Region 'Central Asia' as defined in GCAM version v6.0
+    comment: Region 'Central Asia' as defined in GCAM version 6.0
     children:
     - - ARM
       - AZE
@@ -4129,19 +4129,19 @@ categories:
       - TJK
       - TKM
       - UZB
-  GCAM v6.0|China:
+  GCAM 6.0|China:
     title: China
-    comment: Region 'China' as defined in GCAM version v6.0
+    comment: Region 'China' as defined in GCAM version 6.0
     children:
     - - CHN
-  GCAM v6.0|Colombia:
+  GCAM 6.0|Colombia:
     title: Colombia
-    comment: Region 'Colombia' as defined in GCAM version v6.0
+    comment: Region 'Colombia' as defined in GCAM version 6.0
     children:
     - - COL
-  GCAM v6.0|EU-12:
+  GCAM 6.0|EU-12:
     title: EU-12
-    comment: Region 'EU-12' as defined in GCAM version v6.0
+    comment: Region 'EU-12' as defined in GCAM version 6.0
     children:
     - - BGR
       - CYP
@@ -4155,9 +4155,9 @@ categories:
       - ROU
       - SVK
       - SVN
-  GCAM v6.0|EU-15:
+  GCAM 6.0|EU-15:
     title: EU-15
-    comment: Region 'EU-15' as defined in GCAM version v6.0
+    comment: Region 'EU-15' as defined in GCAM version 6.0
     children:
     - - AND
       - AUT
@@ -4177,23 +4177,23 @@ categories:
       - NLD
       - PRT
       - SWE
-  GCAM v6.0|Europe_Eastern:
+  GCAM 6.0|Europe_Eastern:
     title: Europe_Eastern
-    comment: Region 'Europe_Eastern' as defined in GCAM version v6.0
+    comment: Region 'Europe_Eastern' as defined in GCAM version 6.0
     children:
     - - BLR
       - MDA
       - UKR
-  GCAM v6.0|European Free Trade Association:
+  GCAM 6.0|European Free Trade Association:
     title: European Free Trade Association
-    comment: Region 'European Free Trade Association' as defined in GCAM version v6.0
+    comment: Region 'European Free Trade Association' as defined in GCAM version 6.0
     children:
     - - CHE
       - ISL
       - NOR
-  GCAM v6.0|Europe_Non_EU:
+  GCAM 6.0|Europe_Non_EU:
     title: Europe_Non_EU
-    comment: Region 'Europe_Non_EU' as defined in GCAM version v6.0
+    comment: Region 'Europe_Non_EU' as defined in GCAM version 6.0
     children:
     - - ALB
       - BIH
@@ -4202,29 +4202,29 @@ categories:
       - MNE
       - SRB
       - TUR
-  GCAM v6.0|India:
+  GCAM 6.0|India:
     title: India
-    comment: Region 'India' as defined in GCAM version v6.0
+    comment: Region 'India' as defined in GCAM version 6.0
     children:
     - - IND
-  GCAM v6.0|Indonesia:
+  GCAM 6.0|Indonesia:
     title: Indonesia
-    comment: Region 'Indonesia' as defined in GCAM version v6.0
+    comment: Region 'Indonesia' as defined in GCAM version 6.0
     children:
     - - IDN
-  GCAM v6.0|Japan:
+  GCAM 6.0|Japan:
     title: Japan
-    comment: Region 'Japan' as defined in GCAM version v6.0
+    comment: Region 'Japan' as defined in GCAM version 6.0
     children:
     - - JPN
-  GCAM v6.0|Mexico:
+  GCAM 6.0|Mexico:
     title: Mexico
-    comment: Region 'Mexico' as defined in GCAM version v6.0
+    comment: Region 'Mexico' as defined in GCAM version 6.0
     children:
     - - MEX
-  GCAM v6.0|Middle East:
+  GCAM 6.0|Middle East:
     title: Middle East
-    comment: Region 'Middle East' as defined in GCAM version v6.0
+    comment: Region 'Middle East' as defined in GCAM version 6.0
     children:
     - - ARE
       - BHR
@@ -4240,32 +4240,32 @@ categories:
       - SAU
       - SYR
       - YEM
-  GCAM v6.0|Pakistan:
+  GCAM 6.0|Pakistan:
     title: Pakistan
-    comment: Region 'Pakistan' as defined in GCAM version v6.0
+    comment: Region 'Pakistan' as defined in GCAM version 6.0
     children:
     - - PAK
-  GCAM v6.0|Russia:
+  GCAM 6.0|Russia:
     title: Russia
-    comment: Region 'Russia' as defined in GCAM version v6.0
+    comment: Region 'Russia' as defined in GCAM version 6.0
     children:
     - - RUS
-  GCAM v6.0|South Africa:
+  GCAM 6.0|South Africa:
     title: South Africa
-    comment: Region 'South Africa' as defined in GCAM version v6.0
+    comment: Region 'South Africa' as defined in GCAM version 6.0
     children:
     - - ZAF
-  GCAM v6.0|South America_Northern:
+  GCAM 6.0|South America_Northern:
     title: South America_Northern
-    comment: Region 'South America_Northern' as defined in GCAM version v6.0
+    comment: Region 'South America_Northern' as defined in GCAM version 6.0
     children:
     - - GUF
       - GUY
       - SUR
       - VEN
-  GCAM v6.0|South America_Southern:
+  GCAM 6.0|South America_Southern:
     title: South America_Southern
-    comment: Region 'South America_Southern' as defined in GCAM version v6.0
+    comment: Region 'South America_Southern' as defined in GCAM version 6.0
     children:
     - - BOL
       - CHL
@@ -4273,9 +4273,9 @@ categories:
       - PER
       - PRY
       - URY
-  GCAM v6.0|South Asia:
+  GCAM 6.0|South Asia:
     title: South Asia
-    comment: Region 'South Asia' as defined in GCAM version v6.0
+    comment: Region 'South Asia' as defined in GCAM version 6.0
     children:
     - - AFG
       - BGD
@@ -4283,9 +4283,9 @@ categories:
       - LKA
       - MDV
       - NPL
-  GCAM v6.0|Southeast Asia:
+  GCAM 6.0|Southeast Asia:
     title: Southeast Asia
-    comment: Region 'Southeast Asia' as defined in GCAM version v6.0
+    comment: Region 'Southeast Asia' as defined in GCAM version 6.0
     children:
     - - ASM
       - BRN
@@ -4324,24 +4324,24 @@ categories:
       - VNM
       - VUT
       - WSM
-  GCAM v6.0|South Korea:
+  GCAM 6.0|South Korea:
     title: South Korea
-    comment: Region 'South Korea' as defined in GCAM version v6.0
+    comment: Region 'South Korea' as defined in GCAM version 6.0
     children:
     - - KOR
-  GCAM v6.0|Taiwan:
+  GCAM 6.0|Taiwan:
     title: Taiwan
-    comment: Region 'Taiwan' as defined in GCAM version v6.0
+    comment: Region 'Taiwan' as defined in GCAM version 6.0
     children:
     - - TWN
-  GCAM v6.0|USA:
+  GCAM 6.0|USA:
     title: USA
-    comment: Region 'USA' as defined in GCAM version v6.0
+    comment: Region 'USA' as defined in GCAM version 6.0
     children:
     - - USA
-  GCAM v7.0|Africa_Eastern:
+  GCAM 7.0|Africa_Eastern:
     title: Africa_Eastern
-    comment: Region 'Africa_Eastern' as defined in GCAM version v7.0
+    comment: Region 'Africa_Eastern' as defined in GCAM version 7.0
     children:
     - - BDI
       - COM
@@ -4356,9 +4356,9 @@ categories:
       - SDN
       - SOM
       - UGA
-  GCAM v7.0|Africa_Northern:
+  GCAM 7.0|Africa_Northern:
     title: Africa_Northern
-    comment: Region 'Africa_Northern' as defined in GCAM version v7.0
+    comment: Region 'Africa_Northern' as defined in GCAM version 7.0
     children:
     - - DZA
       - EGY
@@ -4366,9 +4366,9 @@ categories:
       - LBY
       - MAR
       - TUN
-  GCAM v7.0|Africa_Southern:
+  GCAM 7.0|Africa_Southern:
     title: Africa_Southern
-    comment: Region 'Africa_Southern' as defined in GCAM version v7.0
+    comment: Region 'Africa_Southern' as defined in GCAM version 7.0
     children:
     - - AGO
       - BWA
@@ -4380,9 +4380,9 @@ categories:
       - TZA
       - ZMB
       - ZWE
-  GCAM v7.0|Africa_Western:
+  GCAM 7.0|Africa_Western:
     title: Africa_Western
-    comment: Region 'Africa_Western' as defined in GCAM version v7.0
+    comment: Region 'Africa_Western' as defined in GCAM version 7.0
     children:
     - - BEN
       - BFA
@@ -4408,31 +4408,31 @@ categories:
       - STP
       - TCD
       - TGO
-  GCAM v7.0|Argentina:
+  GCAM 7.0|Argentina:
     title: Argentina
-    comment: Region 'Argentina' as defined in GCAM version v7.0
+    comment: Region 'Argentina' as defined in GCAM version 7.0
     children:
     - - ARG
-  GCAM v7.0|Australia_NZ:
+  GCAM 7.0|Australia_NZ:
     title: Australia_NZ
-    comment: Region 'Australia_NZ' as defined in GCAM version v7.0
+    comment: Region 'Australia_NZ' as defined in GCAM version 7.0
     children:
     - - AUS
       - NZL
-  GCAM v7.0|Brazil:
+  GCAM 7.0|Brazil:
     title: Brazil
-    comment: Region 'Brazil' as defined in GCAM version v7.0
+    comment: Region 'Brazil' as defined in GCAM version 7.0
     children:
     - - BRA
-  GCAM v7.0|Canada:
+  GCAM 7.0|Canada:
     title: Canada
-    comment: Region 'Canada' as defined in GCAM version v7.0
+    comment: Region 'Canada' as defined in GCAM version 7.0
     children:
     - - CAN
-  GCAM v7.0|Central America and the Caribbean:
+  GCAM 7.0|Central America and the Caribbean:
     title: Central America and the Caribbean
     comment: Region 'Central America and the Caribbean' as defined in GCAM version
-      v7.0
+      7.0
     children:
     - - ABW
       - AIA
@@ -4461,9 +4461,9 @@ categories:
       - SLV
       - TTO
       - VCT
-  GCAM v7.0|Central Asia:
+  GCAM 7.0|Central Asia:
     title: Central Asia
-    comment: Region 'Central Asia' as defined in GCAM version v7.0
+    comment: Region 'Central Asia' as defined in GCAM version 7.0
     children:
     - - ARM
       - AZE
@@ -4474,19 +4474,19 @@ categories:
       - TJK
       - TKM
       - UZB
-  GCAM v7.0|China:
+  GCAM 7.0|China:
     title: China
-    comment: Region 'China' as defined in GCAM version v7.0
+    comment: Region 'China' as defined in GCAM version 7.0
     children:
     - - CHN
-  GCAM v7.0|Colombia:
+  GCAM 7.0|Colombia:
     title: Colombia
-    comment: Region 'Colombia' as defined in GCAM version v7.0
+    comment: Region 'Colombia' as defined in GCAM version 7.0
     children:
     - - COL
-  GCAM v7.0|EU-12:
+  GCAM 7.0|EU-12:
     title: EU-12
-    comment: Region 'EU-12' as defined in GCAM version v7.0
+    comment: Region 'EU-12' as defined in GCAM version 7.0
     children:
     - - BGR
       - CYP
@@ -4500,9 +4500,9 @@ categories:
       - ROU
       - SVK
       - SVN
-  GCAM v7.0|EU-15:
+  GCAM 7.0|EU-15:
     title: EU-15
-    comment: Region 'EU-15' as defined in GCAM version v7.0
+    comment: Region 'EU-15' as defined in GCAM version 7.0
     children:
     - - AND
       - AUT
@@ -4522,23 +4522,23 @@ categories:
       - NLD
       - PRT
       - SWE
-  GCAM v7.0|Europe_Eastern:
+  GCAM 7.0|Europe_Eastern:
     title: Europe_Eastern
-    comment: Region 'Europe_Eastern' as defined in GCAM version v7.0
+    comment: Region 'Europe_Eastern' as defined in GCAM version 7.0
     children:
     - - BLR
       - MDA
       - UKR
-  GCAM v7.0|European Free Trade Association:
+  GCAM 7.0|European Free Trade Association:
     title: European Free Trade Association
-    comment: Region 'European Free Trade Association' as defined in GCAM version v7.0
+    comment: Region 'European Free Trade Association' as defined in GCAM version 7.0
     children:
     - - CHE
       - ISL
       - NOR
-  GCAM v7.0|Europe_Non_EU:
+  GCAM 7.0|Europe_Non_EU:
     title: Europe_Non_EU
-    comment: Region 'Europe_Non_EU' as defined in GCAM version v7.0
+    comment: Region 'Europe_Non_EU' as defined in GCAM version 7.0
     children:
     - - ALB
       - BIH
@@ -4547,29 +4547,29 @@ categories:
       - MNE
       - SRB
       - TUR
-  GCAM v7.0|India:
+  GCAM 7.0|India:
     title: India
-    comment: Region 'India' as defined in GCAM version v7.0
+    comment: Region 'India' as defined in GCAM version 7.0
     children:
     - - IND
-  GCAM v7.0|Indonesia:
+  GCAM 7.0|Indonesia:
     title: Indonesia
-    comment: Region 'Indonesia' as defined in GCAM version v7.0
+    comment: Region 'Indonesia' as defined in GCAM version 7.0
     children:
     - - IDN
-  GCAM v7.0|Japan:
+  GCAM 7.0|Japan:
     title: Japan
-    comment: Region 'Japan' as defined in GCAM version v7.0
+    comment: Region 'Japan' as defined in GCAM version 7.0
     children:
     - - JPN
-  GCAM v7.0|Mexico:
+  GCAM 7.0|Mexico:
     title: Mexico
-    comment: Region 'Mexico' as defined in GCAM version v7.0
+    comment: Region 'Mexico' as defined in GCAM version 7.0
     children:
     - - MEX
-  GCAM v7.0|Middle East:
+  GCAM 7.0|Middle East:
     title: Middle East
-    comment: Region 'Middle East' as defined in GCAM version v7.0
+    comment: Region 'Middle East' as defined in GCAM version 7.0
     children:
     - - ARE
       - BHR
@@ -4585,32 +4585,32 @@ categories:
       - SAU
       - SYR
       - YEM
-  GCAM v7.0|Pakistan:
+  GCAM 7.0|Pakistan:
     title: Pakistan
-    comment: Region 'Pakistan' as defined in GCAM version v7.0
+    comment: Region 'Pakistan' as defined in GCAM version 7.0
     children:
     - - PAK
-  GCAM v7.0|Russia:
+  GCAM 7.0|Russia:
     title: Russia
-    comment: Region 'Russia' as defined in GCAM version v7.0
+    comment: Region 'Russia' as defined in GCAM version 7.0
     children:
     - - RUS
-  GCAM v7.0|South Africa:
+  GCAM 7.0|South Africa:
     title: South Africa
-    comment: Region 'South Africa' as defined in GCAM version v7.0
+    comment: Region 'South Africa' as defined in GCAM version 7.0
     children:
     - - ZAF
-  GCAM v7.0|South America_Northern:
+  GCAM 7.0|South America_Northern:
     title: South America_Northern
-    comment: Region 'South America_Northern' as defined in GCAM version v7.0
+    comment: Region 'South America_Northern' as defined in GCAM version 7.0
     children:
     - - GUF
       - GUY
       - SUR
       - VEN
-  GCAM v7.0|South America_Southern:
+  GCAM 7.0|South America_Southern:
     title: South America_Southern
-    comment: Region 'South America_Southern' as defined in GCAM version v7.0
+    comment: Region 'South America_Southern' as defined in GCAM version 7.0
     children:
     - - BOL
       - CHL
@@ -4618,9 +4618,9 @@ categories:
       - PER
       - PRY
       - URY
-  GCAM v7.0|South Asia:
+  GCAM 7.0|South Asia:
     title: South Asia
-    comment: Region 'South Asia' as defined in GCAM version v7.0
+    comment: Region 'South Asia' as defined in GCAM version 7.0
     children:
     - - AFG
       - BGD
@@ -4628,9 +4628,9 @@ categories:
       - LKA
       - MDV
       - NPL
-  GCAM v7.0|Southeast Asia:
+  GCAM 7.0|Southeast Asia:
     title: Southeast Asia
-    comment: Region 'Southeast Asia' as defined in GCAM version v7.0
+    comment: Region 'Southeast Asia' as defined in GCAM version 7.0
     children:
     - - ASM
       - BRN
@@ -4669,18 +4669,18 @@ categories:
       - VNM
       - VUT
       - WSM
-  GCAM v7.0|South Korea:
+  GCAM 7.0|South Korea:
     title: South Korea
-    comment: Region 'South Korea' as defined in GCAM version v7.0
+    comment: Region 'South Korea' as defined in GCAM version 7.0
     children:
     - - KOR
-  GCAM v7.0|Taiwan:
+  GCAM 7.0|Taiwan:
     title: Taiwan
-    comment: Region 'Taiwan' as defined in GCAM version v7.0
+    comment: Region 'Taiwan' as defined in GCAM version 7.0
     children:
     - - TWN
-  GCAM v7.0|USA:
+  GCAM 7.0|USA:
     title: USA
-    comment: Region 'USA' as defined in GCAM version v7.0
+    comment: Region 'USA' as defined in GCAM version 7.0
     children:
     - - USA

--- a/climate_categories/tests/test_iso3.py
+++ b/climate_categories/tests/test_iso3.py
@@ -57,6 +57,6 @@ def test_aosis():
 
 def test_gcam():
     assert (
-        len(climate_categories.ISO3_GCAM["GCAM v7.0|Southeast Asia"].leaf_children[0])
+        len(climate_categories.ISO3_GCAM["GCAM 7.0|Southeast Asia"].leaf_children[0])
         == 37
     )

--- a/data_generation/ISO3_GCAM.py
+++ b/data_generation/ISO3_GCAM.py
@@ -18,11 +18,11 @@ def main():
     categories = {}
     children = []
 
-    for gcam_version in tqdm.tqdm(("v5.1", "v5.2", "v5.3", "v5.4", "v6.0", "v7.0")):
-        if gcam_version == "v7.0":
+    for gcam_version in tqdm.tqdm(("5.1", "5.2", "5.3", "5.4", "6.0", "7.0")):
+        if gcam_version == "7.0":
             url = "https://jgcri.github.io/gcam-doc/overview.html"
         else:
-            url = f"https://jgcri.github.io/gcam-doc/{gcam_version}/overview.html"
+            url = f"https://jgcri.github.io/gcam-doc/v{gcam_version}/overview.html"
         gcam_regions_df = pd.read_html(url, match="GCAM Region", header=0, index_col=0)[
             0
         ]


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog snippet in a `.rst` file in the directory `changelog_unreleased` added – remember to start with a `*` to make it a bullet point

## Description

GCAM doesn't include "v" in their version specified in region codes
